### PR TITLE
Limit max bounty to 99%

### DIFF
--- a/contracts/HATVault.sol
+++ b/contracts/HATVault.sol
@@ -75,8 +75,8 @@ contract HATVault is Claim, Deposits, Params, Withdrawals {
         address _committee,
         bool _isPaused
     ) external initializer {
-        if (_maxBounty > HUNDRED_PERCENT)
-            revert MaxBountyCannotBeMoreThanHundredPercent();
+        if (_maxBounty > MAX_BOUNTY_LIMIT)
+            revert MaxBountyCannotBeMoreThanMaxBountyLimit();
         validateSplit(_bountySplit);
         __ERC4626_init(IERC20MetadataUpgradeable(address(_asset)));
         rewardController = _rewardController;

--- a/contracts/vaults/Base.sol
+++ b/contracts/vaults/Base.sol
@@ -50,8 +50,8 @@ error VaultBalanceIsZero();
 error TotalSplitPercentageShouldBeHundredPercent();
 // Withdraw request is invalid
 error InvalidWithdrawRequest();
-// Max bounty cannot be more than `HUNDRED_PERCENT`
-error MaxBountyCannotBeMoreThanHundredPercent();
+// Max bounty cannot be more than `MAX_BOUNTY_LIMIT`
+error MaxBountyCannotBeMoreThanMaxBountyLimit();
 // Only fee setter
 error OnlyFeeSetter();
 // Fee must be less than or equal to 2%
@@ -127,6 +127,7 @@ contract Base is ERC4626Upgradeable, ReentrancyGuardUpgradeable {
     }
 
     uint256 public constant HUNDRED_PERCENT = 10000;
+    uint256 public constant MAX_BOUNTY_LIMIT = 9900; // Max bounty can be uup to 99%
     uint256 public constant HUNDRED_PERCENT_SQRD = 100000000;
     uint256 public constant MAX_FEE = 200; // Max fee is 2%
 

--- a/contracts/vaults/Base.sol
+++ b/contracts/vaults/Base.sol
@@ -127,7 +127,7 @@ contract Base is ERC4626Upgradeable, ReentrancyGuardUpgradeable {
     }
 
     uint256 public constant HUNDRED_PERCENT = 10000;
-    uint256 public constant MAX_BOUNTY_LIMIT = 9900; // Max bounty can be uup to 99%
+    uint256 public constant MAX_BOUNTY_LIMIT = 9000; // Max bounty can be up to 90%
     uint256 public constant HUNDRED_PERCENT_SQRD = 100000000;
     uint256 public constant MAX_FEE = 200; // Max fee is 2%
 

--- a/contracts/vaults/Params.sol
+++ b/contracts/vaults/Params.sol
@@ -87,13 +87,14 @@ contract Params is Base {
     * Max bounty should be less than or equal to `HUNDRED_PERCENT`.
     * The pending value can later be set after the time delay (of 
     * HATVaultsRegistry.GeneralParameters.setMaxBountyDelay) had passed.
+    * Max bounty should be less than or equal to `MAX_BOUNTY_LIMIT`
     * @param _maxBounty The maximum bounty percentage that can be paid out
     */
     function setPendingMaxBounty(uint256 _maxBounty)
     external
     onlyCommittee noActiveClaim {
-        if (_maxBounty > HUNDRED_PERCENT)
-            revert MaxBountyCannotBeMoreThanHundredPercent();
+        if (_maxBounty > MAX_BOUNTY_LIMIT)
+            revert MaxBountyCannotBeMoreThanMaxBountyLimit();
         pendingMaxBounty.maxBounty = _maxBounty;
         // solhint-disable-next-line not-rely-on-time
         pendingMaxBounty.timestamp = block.timestamp;
@@ -106,6 +107,7 @@ contract Params is Base {
     * Cannot be called if there are active claims that have been submitted.
     * Can only be called if there is a max bounty pending approval, and the
     * time delay since setting the pending max bounty had passed.
+    * Max bounty should be less than or equal to `MAX_BOUNTY_LIMIT`
     */
     function setMaxBounty() external onlyCommittee noActiveClaim {
         if (pendingMaxBounty.timestamp == 0) revert NoPendingMaxBounty();

--- a/test/hatvaults.js
+++ b/test/hatvaults.js
@@ -430,13 +430,13 @@ contract("HatVaults", (accounts) => {
     );
 
     try {
-      await vault.setPendingMaxBounty(9901, { from: accounts[1] });
-      assert(false, "max bounty can't be more than 9900");
+      await vault.setPendingMaxBounty(9001, { from: accounts[1] });
+      assert(false, "max bounty can't be more than 9000");
     } catch (ex) {
       assertVMException(ex, "MaxBountyCannotBeMoreThanMaxBountyLimit");
     }
     try {
-      await vault.setPendingMaxBounty(9900, { from: accounts[2] });
+      await vault.setPendingMaxBounty(9000, { from: accounts[2] });
       assert(false, "only committee");
     } catch (ex) {
       assertVMException(ex, "OnlyCommittee");
@@ -448,22 +448,22 @@ contract("HatVaults", (accounts) => {
       assertVMException(ex, "NoPendingMaxBounty");
     }
 
-    // bountylevel can be 9900 without throwing an error
-    await vault.setPendingMaxBounty(9900, {
+    // bountylevel can be 9000 without throwing an error
+    await vault.setPendingMaxBounty(9000, {
       from: accounts[1],
     });
 
     try {
-      await vault.setPendingMaxBounty(9901, { from: accounts[1] });
-      assert(false, "bounty level should be less than or equal to 9900");
+      await vault.setPendingMaxBounty(9001, { from: accounts[1] });
+      assert(false, "bounty level should be less than or equal to 9000");
     } catch (ex) {
       assertVMException(ex, "MaxBountyCannotBeMoreThanMaxBountyLimit");
     }
-    let tx = await vault.setPendingMaxBounty(9900, {
+    let tx = await vault.setPendingMaxBounty(9000, {
       from: accounts[1],
     });
     assert.equal(tx.logs[0].event, "SetPendingMaxBounty");
-    assert.equal(tx.logs[0].args._maxBounty, 9900);
+    assert.equal(tx.logs[0].args._maxBounty, 9000);
 
     await utils.increaseTime(1);
     try {
@@ -481,7 +481,7 @@ contract("HatVaults", (accounts) => {
     }
     tx = await vault.setMaxBounty({ from: accounts[1] });
     assert.equal(tx.logs[0].event, "SetMaxBounty");
-    assert.equal(tx.logs[0].args._maxBounty, 9900);
+    assert.equal(tx.logs[0].args._maxBounty, 9000);
 
     await advanceToNonSafetyPeriod();
 
@@ -494,7 +494,7 @@ contract("HatVaults", (accounts) => {
     await vault.setBountySplit([6000, 0, 1000, 2200, 0, 800]);
     assert.equal(
       (await vault.maxBounty()).toString(),
-      "9900"
+      "9000"
     );
     assert.equal(
       (await vault.bountySplit()).hacker.toString(),
@@ -520,7 +520,7 @@ contract("HatVaults", (accounts) => {
     await advanceToSafetyPeriod();
     tx = await vault.submitClaim(
       accounts[2],
-      9900,
+      9000,
       "description hash",
       {
         from: accounts[1],

--- a/test/hatvaults.js
+++ b/test/hatvaults.js
@@ -395,10 +395,10 @@ contract("HatVaults", (accounts) => {
     }
 
     try {
-      await setup(accounts, 0, 11000, [8000, 0, 100, 0, 100, 800]);
+      await setup(accounts, 0, 9901, [8000, 0, 100, 0, 100, 800]);
       assert(false, "cannot init with max bounty > 10000");
     } catch (ex) {
-      assertVMException(ex, "MaxBountyCannotBeMoreThanHundredPercent");
+      assertVMException(ex, "MaxBountyCannotBeMoreThanMaxBountyLimit");
     }
 
     await setup(accounts, 0, 9000, [8000, 1000, 100, 100, 100, 700], 10, 0, 100, false, 2500000, 60 * 60 * 24 * 3);
@@ -430,13 +430,13 @@ contract("HatVaults", (accounts) => {
     );
 
     try {
-      await vault.setPendingMaxBounty(11000, { from: accounts[1] });
-      assert(false, "max bounty can't be more than 10000");
+      await vault.setPendingMaxBounty(9901, { from: accounts[1] });
+      assert(false, "max bounty can't be more than 9900");
     } catch (ex) {
-      assertVMException(ex, "MaxBountyCannotBeMoreThanHundredPercent");
+      assertVMException(ex, "MaxBountyCannotBeMoreThanMaxBountyLimit");
     }
     try {
-      await vault.setPendingMaxBounty(10000, { from: accounts[2] });
+      await vault.setPendingMaxBounty(9900, { from: accounts[2] });
       assert(false, "only committee");
     } catch (ex) {
       assertVMException(ex, "OnlyCommittee");
@@ -448,22 +448,22 @@ contract("HatVaults", (accounts) => {
       assertVMException(ex, "NoPendingMaxBounty");
     }
 
-    // bountylevel can be 10000 without throwing an error
-    await vault.setPendingMaxBounty(10000, {
+    // bountylevel can be 9900 without throwing an error
+    await vault.setPendingMaxBounty(9900, {
       from: accounts[1],
     });
 
     try {
-      await vault.setPendingMaxBounty(10001, { from: accounts[1] });
-      assert(false, "bounty level should be less than or equal to 10000");
+      await vault.setPendingMaxBounty(9901, { from: accounts[1] });
+      assert(false, "bounty level should be less than or equal to 9900");
     } catch (ex) {
-      assertVMException(ex, "MaxBountyCannotBeMoreThanHundredPercent");
+      assertVMException(ex, "MaxBountyCannotBeMoreThanMaxBountyLimit");
     }
-    let tx = await vault.setPendingMaxBounty(10000, {
+    let tx = await vault.setPendingMaxBounty(9900, {
       from: accounts[1],
     });
     assert.equal(tx.logs[0].event, "SetPendingMaxBounty");
-    assert.equal(tx.logs[0].args._maxBounty, 10000);
+    assert.equal(tx.logs[0].args._maxBounty, 9900);
 
     await utils.increaseTime(1);
     try {
@@ -481,7 +481,7 @@ contract("HatVaults", (accounts) => {
     }
     tx = await vault.setMaxBounty({ from: accounts[1] });
     assert.equal(tx.logs[0].event, "SetMaxBounty");
-    assert.equal(tx.logs[0].args._maxBounty, 10000);
+    assert.equal(tx.logs[0].args._maxBounty, 9900);
 
     await advanceToNonSafetyPeriod();
 
@@ -494,7 +494,7 @@ contract("HatVaults", (accounts) => {
     await vault.setBountySplit([6000, 0, 1000, 2200, 0, 800]);
     assert.equal(
       (await vault.maxBounty()).toString(),
-      "10000"
+      "9900"
     );
     assert.equal(
       (await vault.bountySplit()).hacker.toString(),
@@ -520,7 +520,7 @@ contract("HatVaults", (accounts) => {
     await advanceToSafetyPeriod();
     tx = await vault.submitClaim(
       accounts[2],
-      10000,
+      9900,
       "description hash",
       {
         from: accounts[1],


### PR DESCRIPTION
Limits the max bounty to 99% of the vault funds ( Fix #208 )