### PR TITLE
Audit fixes adam

### DIFF
--- a/contracts/HATVault.sol
+++ b/contracts/HATVault.sol
@@ -703,6 +703,7 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
         address to,
         uint256 amount
     ) internal virtual override {
+        if (amount == 0) revert AmountToTransferIsZero();
         // deposit/mint/transfer
         if (to != address(0)) {
             if (registry.isEmergencyPaused()) revert SystemInEmergencyPause();
@@ -760,7 +761,7 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
         // last action was withdrawRequest (and not deposit or withdraw, which
         // reset withdrawRequests[_user] to 0)
         // solhint-disable-next-line not-rely-on-time
-            block.timestamp <=
+            block.timestamp <
                 withdrawEnableStartTime[_user] +
                 generalParameters.withdrawRequestEnablePeriod);
     }

--- a/contracts/HATVault.sol
+++ b/contracts/HATVault.sol
@@ -664,7 +664,6 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
     ) internal override virtual nonReentrant {
         if (!committeeCheckedIn)
             revert CommitteeNotCheckedInYet();
-        if (shares == 0) revert AmountToDepositIsZero();
         if (withdrawEnableStartTime[receiver] != 0 && receiver == caller) {
             // clear withdraw request if caller deposits in her own account
             withdrawEnableStartTime[receiver] = 0;
@@ -703,7 +702,7 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
         address to,
         uint256 amount
     ) internal virtual override {
-        if (amount == 0) revert AmountToTransferIsZero();
+        if (amount == 0) revert AmountIsZero();
         // deposit/mint/transfer
         if (to != address(0)) {
             if (registry.isEmergencyPaused()) revert SystemInEmergencyPause();

--- a/contracts/interfaces/IHATVault.sol
+++ b/contracts/interfaces/IHATVault.sol
@@ -128,10 +128,8 @@ interface IHATVault is IERC4626Upgradeable {
     error CommitteeAlreadyCheckedIn();
     // Pending withdraw request exists
     error PendingWithdrawRequestExists();
-    // Amount to deposit is zero
-    error AmountToDepositIsZero();
-    // Amount to withdraw is zero
-    error AmountToWithdrawIsZero();
+    // Amount to transfer/withdraw/deposit is zero
+    error AmountIsZero();
     // Total bounty split % should be `HUNDRED_PERCENT`
     error TotalSplitPercentageShouldBeHundredPercent();
     // Vesting duration is too long

--- a/contracts/interfaces/IHATVault.sol
+++ b/contracts/interfaces/IHATVault.sol
@@ -130,6 +130,8 @@ interface IHATVault is IERC4626Upgradeable {
     error PendingWithdrawRequestExists();
     // Amount to deposit is zero
     error AmountToDepositIsZero();
+    // Amount to withdraw is zero
+    error AmountToWithdrawIsZero();
     // Total bounty split % should be `HUNDRED_PERCENT`
     error TotalSplitPercentageShouldBeHundredPercent();
     // Vesting duration is too long

--- a/test/hatvaults.js
+++ b/test/hatvaults.js
@@ -1079,7 +1079,7 @@ contract("HatVaults", (accounts) => {
       await vault.mint(0, staker, { from: staker });
       assert(false, "cannot deposit 0");
     } catch (ex) {
-      assertVMException(ex, "AmountToDepositIsZero");
+      assertVMException(ex, "AmountIsZero");
     }
 
     await vault.deposit(1, staker, { from: staker });
@@ -1090,7 +1090,7 @@ contract("HatVaults", (accounts) => {
       await vault.deposit(1, staker, { from: staker });
       assert(false, "cannot deposit amount too low for 1 share");
     } catch (ex) {
-      assertVMException(ex, "AmountToDepositIsZero");
+      assertVMException(ex, "AmountIsZero");
     }
   });
 


### PR DESCRIPTION
adam's comments:
1) this check: https://github.com/hats-finance/hats-contracts/blob/1272ef58df5d65fcc8d4cddbb23772cd4a6a5cf3/contracts/HATVault.sol#L498 can be bypassed by doing a zero token transfer, which will always succeed and will reset withdrawEnableStartTime[from] to 0
see:
https://github.com/hats-finance/hats-contracts/blob/1272ef58df5d65fcc8d4cddbb23772cd4a6a5cf3/contracts/HATVault.sol#L725
-> suggests to remove the check in https://github.com/hats-finance/hats-contracts/blob/1272ef58df5d65fcc8d4cddbb23772cd4a6a5cf3/contracts/HATVault.sol#L498

2) these two intervals:
https://github.com/hats-finance/hats-contracts/blob/1272ef58df5d65fcc8d4cddbb23772cd4a6a5cf3/contracts/HATVault.sol#L714
and
https://github.com/hats-finance/hats-contracts/blob/1272ef58df5d65fcc8d4cddbb23772cd4a6a5cf3/contracts/HATVault.sol#L763

overlap, meaning if the block timestamp is just right, you can receive shares and send them in the same block. Not sure if it's exploitable, but should be fixed.

-> change `<=` to `<` in https://github.com/hats-finance/hats-contracts/blob/1272ef58df5d65fcc8d4cddbb23772cd4a6a5cf3/contracts/HATVault.sol#L763

3) transfer of shares with the same to and from will lead to weird behavior due to the commitUserBalance calls, most likely ending in an underflow error, but might be even exploitable if rounding issues are exploited

-> fixed by fixing point 2

4) A user can call HATVault.transferFrom with 0 amount and arbitrary from which will always pass. This will lead to withdrawEnableStartTime[from] being set to 0. This basically allows anybody to block all transactions of any address.

-> add check in `_beforeTokenTransfer`

5) HATVault.withdraw is confusing and I'm not entierely sure whether it's correct. Especially rounding up when converting to assets here seems dubious. https://github.com/hats-finance/hats-contracts/blob/1272ef58df5d65fcc8d4cddbb23772cd4a6a5cf3/contracts/HATVault.sol#L532
Instead of the back and forth conversion, I'd recommend a version of calculating fee that's more easy to reason about.


    /** @notice See {IHATVault-withdraw}. */ 
    function withdraw(uint256 assets, address receiver, address owner)  
        public override(IHATVault, ERC4626Upgradeable) virtual returns (uint256) { 
        uint256 shares = previewWithdraw(assets); 
        uint256 fee = assets * HUNDRED_PERCENT / (HUNDRED_PERCENT - withdrawalFee) - assets; 
        _withdraw(_msgSender(), receiver, owner, assets, shares, fee); 
        return shares; 
    }
