### PR TITLE
Adam Audit fixes

### DIFF
--- a/contracts/HATVault.sol
+++ b/contracts/HATVault.sol
@@ -576,7 +576,7 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
     function previewWithdrawAndFee(uint256 assets) public view returns (uint256 shares, uint256 fee) {
         uint256 assetsPlusFee = (assets * HUNDRED_PERCENT / (HUNDRED_PERCENT - withdrawalFee));
         fee = assets * withdrawalFee / (HUNDRED_PERCENT - withdrawalFee);
-        shares = _convertToShares(assetsPlusFee, MathUpgradeable.Rounding.Up);
+        shares = _convertToShares(assets + fee, MathUpgradeable.Rounding.Up);
     }
 
     /** @notice See {IHATVault-previewRedeemAndFee}. */

--- a/contracts/HATVault.sol
+++ b/contracts/HATVault.sol
@@ -574,7 +574,6 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
 
     /** @notice See {IHATVault-previewWithdrawAndFee}. */
     function previewWithdrawAndFee(uint256 assets) public view returns (uint256 shares, uint256 fee) {
-        uint256 assetsPlusFee = (assets * HUNDRED_PERCENT / (HUNDRED_PERCENT - withdrawalFee));
         fee = assets * withdrawalFee / (HUNDRED_PERCENT - withdrawalFee);
         shares = _convertToShares(assets + fee, MathUpgradeable.Rounding.Up);
     }

--- a/contracts/HATVault.sol
+++ b/contracts/HATVault.sol
@@ -492,13 +492,6 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
     /** @notice See {IHATVault-withdrawRequest}. */
     function withdrawRequest() external nonReentrant {
         IHATVaultsRegistry.GeneralParameters memory generalParameters = registry.getGeneralParameters();
-        // require withdraw to be at least withdrawRequestEnablePeriod+withdrawRequestPendingPeriod
-        // since last withdrawRequest (meaning the last withdraw request had expired)
-        // solhint-disable-next-line not-rely-on-time
-        if (block.timestamp <
-            withdrawEnableStartTime[msg.sender] +
-                generalParameters.withdrawRequestEnablePeriod)
-            revert PendingWithdrawRequestExists();
         // set the withdrawEnableStartTime time to be withdrawRequestPendingPeriod from now
         // solhint-disable-next-line not-rely-on-time
         withdrawEnableStartTime[msg.sender] = block.timestamp + generalParameters.withdrawRequestPendingPeriod;

--- a/contracts/HATVault.sol
+++ b/contracts/HATVault.sol
@@ -520,9 +520,8 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
     /** @notice See {IHATVault-withdraw}. */
     function withdraw(uint256 assets, address receiver, address owner) 
         public override(IHATVault, ERC4626Upgradeable) virtual returns (uint256) {
-
         uint256 shares = previewWithdraw(assets);
-        uint256 fee = _convertToAssets(shares - _convertToShares(assets, MathUpgradeable.Rounding.Up), MathUpgradeable.Rounding.Up);
+        uint256 fee = assets * HUNDRED_PERCENT / (HUNDRED_PERCENT - withdrawalFee) - assets;
         _withdraw(_msgSender(), receiver, owner, assets, shares, fee);
 
         return shares;
@@ -530,8 +529,7 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
 
     /** @notice See {IHATVault-redeem}. */
     function redeem(uint256 shares, address receiver, address owner) 
-        public  override(IHATVault, ERC4626Upgradeable) virtual returns (uint256) {
-
+        public override(IHATVault, ERC4626Upgradeable) virtual returns (uint256) {
         uint256 assets = previewRedeem(shares);
         uint256 fee = _convertToAssets(shares, MathUpgradeable.Rounding.Down) - assets;
         _withdraw(_msgSender(), receiver, owner, assets, shares, fee);

--- a/contracts/HATVault.sol
+++ b/contracts/HATVault.sol
@@ -693,7 +693,7 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
         address to,
         uint256 amount
     ) internal virtual override {
-        if (amount == 0) revert TransferAmountCannotBeZero();
+        if (amount == 0) revert AmountCannotBeZero();
         if (from == to) revert CannotTransferToSelf();
         // deposit/mint/transfer
         if (to != address(0)) {

--- a/contracts/HATVault.sol
+++ b/contracts/HATVault.sol
@@ -696,6 +696,7 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
         address to,
         uint256 amount
     ) internal virtual override {
+        if (amount == 0) revert TransferAmountCannotBeZero();
         // deposit/mint/transfer
         if (to != address(0)) {
             if (registry.isEmergencyPaused()) revert SystemInEmergencyPause();

--- a/contracts/HATVault.sol
+++ b/contracts/HATVault.sol
@@ -760,7 +760,7 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
         // last action was withdrawRequest (and not deposit or withdraw, which
         // reset withdrawRequests[_user] to 0)
         // solhint-disable-next-line not-rely-on-time
-            block.timestamp <=
+            block.timestamp <
                 withdrawEnableStartTime[_user] +
                 generalParameters.withdrawRequestEnablePeriod);
     }

--- a/contracts/HATVault.sol
+++ b/contracts/HATVault.sol
@@ -655,7 +655,6 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
     ) internal override virtual nonReentrant {
         if (!committeeCheckedIn)
             revert CommitteeNotCheckedInYet();
-        if (shares == 0) revert AmountToDepositIsZero();
         if (withdrawEnableStartTime[receiver] != 0 && receiver == caller) {
             // clear withdraw request if caller deposits in her own account
             withdrawEnableStartTime[receiver] = 0;

--- a/contracts/HATVault.sol
+++ b/contracts/HATVault.sol
@@ -521,7 +521,7 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
     function withdraw(uint256 assets, address receiver, address owner) 
         public override(IHATVault, ERC4626Upgradeable) virtual returns (uint256) {
         uint256 shares = previewWithdraw(assets);
-        uint256 fee = assets * HUNDRED_PERCENT / (HUNDRED_PERCENT - withdrawalFee) - assets;
+        uint256 fee = assets * withdrawalFee / (HUNDRED_PERCENT - withdrawalFee);
         _withdraw(_msgSender(), receiver, owner, assets, shares, fee);
 
         return shares;

--- a/contracts/HATVault.sol
+++ b/contracts/HATVault.sol
@@ -697,6 +697,7 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
         uint256 amount
     ) internal virtual override {
         if (amount == 0) revert TransferAmountCannotBeZero();
+        if (from == to) revert CannotTransferToSelf();
         // deposit/mint/transfer
         if (to != address(0)) {
             if (registry.isEmergencyPaused()) revert SystemInEmergencyPause();

--- a/contracts/interfaces/IHATVault.sol
+++ b/contracts/interfaces/IHATVault.sol
@@ -174,8 +174,8 @@ interface IHATVault is IERC4626Upgradeable {
     error SystemInEmergencyPause();
     // Cannot set a reward controller that was already used in the past
     error CannotSetToPerviousRewardController();
-    // Cannot transfer 0 amount of shares
-    error TransferAmountCannotBeZero();
+    // Cannot mint burn or transfer 0 amount of shares
+    error AmountCannotBeZero();
     // Cannot transfer shares to self
     error CannotTransferToSelf();
 

--- a/contracts/interfaces/IHATVault.sol
+++ b/contracts/interfaces/IHATVault.sol
@@ -126,8 +126,6 @@ interface IHATVault is IERC4626Upgradeable {
     error DelayPeriodForSettingMaxBountyHadNotPassed();
     // Committee already checked in
     error CommitteeAlreadyCheckedIn();
-    // Pending withdraw request exists
-    error PendingWithdrawRequestExists();
     // Amount to deposit is zero
     error AmountToDepositIsZero();
     // Total bounty split % should be `HUNDRED_PERCENT`

--- a/contracts/interfaces/IHATVault.sol
+++ b/contracts/interfaces/IHATVault.sol
@@ -176,7 +176,8 @@ interface IHATVault is IERC4626Upgradeable {
     error SystemInEmergencyPause();
     // Cannot set a reward controller that was already used in the past
     error CannotSetToPerviousRewardController();
-
+    // Cannot transfer 0 amount of shares
+    error TransferAmountCannotBeZero();
 
     
     event SubmitClaim(

--- a/contracts/interfaces/IHATVault.sol
+++ b/contracts/interfaces/IHATVault.sol
@@ -586,7 +586,7 @@ interface IHATVault is IERC4626Upgradeable {
     /** 
     * @notice Returns the amount of assets to be sent to the user for the exact
     * amount of shares to redeem. Also returns the amount assets to be paid as fee.
-    * @return assets amound of assets to be sent in exchange for the amount of shares specified
+    * @return assets amount of assets to be sent in exchange for the amount of shares specified
     * @return fee The amount of assets that will be paid as fee
     */
     function previewRedeemAndFee(uint256 shares) external view returns (uint256 assets, uint256 fee);

--- a/contracts/interfaces/IHATVault.sol
+++ b/contracts/interfaces/IHATVault.sol
@@ -573,4 +573,21 @@ interface IHATVault is IERC4626Upgradeable {
     */
     function getChallengeTimeOutPeriod() external view returns(uint256);
 
+    /** 
+    * @notice Returns the amount of shares to be burned to give the user the exact
+    * amount of assets requested plus cover for the fee. Also returns the amount assets
+    * to be paid as fee.
+    * @return shares The amound of shares to be burned to get the requested amount of assets
+    * @return fee The amount of assets that will be paid as fee
+    */
+    function previewWithdrawAndFee(uint256 assets) external view returns (uint256 shares, uint256 fee);
+
+
+    /** 
+    * @notice Returns the amount of assets to be sent to the user for the exact
+    * amount of shares to redeem. Also returns the amount assets to be paid as fee.
+    * @return assets amound of assets to be sent in exchange for the amount of shares specified
+    * @return fee The amount of assets that will be paid as fee
+    */
+    function previewRedeemAndFee(uint256 shares) external view returns (uint256 assets, uint256 fee);
 }

--- a/contracts/interfaces/IHATVault.sol
+++ b/contracts/interfaces/IHATVault.sol
@@ -577,7 +577,7 @@ interface IHATVault is IERC4626Upgradeable {
     * @notice Returns the amount of shares to be burned to give the user the exact
     * amount of assets requested plus cover for the fee. Also returns the amount assets
     * to be paid as fee.
-    * @return shares The amound of shares to be burned to get the requested amount of assets
+    * @return shares The amount of shares to be burned to get the requested amount of assets
     * @return fee The amount of assets that will be paid as fee
     */
     function previewWithdrawAndFee(uint256 assets) external view returns (uint256 shares, uint256 fee);

--- a/contracts/interfaces/IHATVault.sol
+++ b/contracts/interfaces/IHATVault.sol
@@ -178,6 +178,8 @@ interface IHATVault is IERC4626Upgradeable {
     error CannotSetToPerviousRewardController();
     // Cannot transfer 0 amount of shares
     error TransferAmountCannotBeZero();
+    // Cannot transfer shares to self
+    error CannotTransferToSelf();
 
     
     event SubmitClaim(

--- a/contracts/interfaces/IHATVault.sol
+++ b/contracts/interfaces/IHATVault.sol
@@ -126,8 +126,6 @@ interface IHATVault is IERC4626Upgradeable {
     error DelayPeriodForSettingMaxBountyHadNotPassed();
     // Committee already checked in
     error CommitteeAlreadyCheckedIn();
-    // Amount to deposit is zero
-    error AmountToDepositIsZero();
     // Total bounty split % should be `HUNDRED_PERCENT`
     error TotalSplitPercentageShouldBeHundredPercent();
     // Vesting duration is too long

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -8,7 +8,7 @@ The HATVaults system depends a number of roles that together manage the system a
 - `arbitrator` - the party that is responsible for resolving disputes regarding claims
 
 
-## Publicly avilable functions
+## Publicly available functions
 
 - `registry.createVault`
 

--- a/test/hatvaults.js
+++ b/test/hatvaults.js
@@ -3769,6 +3769,13 @@ it("getVaultReward - no vault updates will retrun 0 ", async () => {
       assertVMException(ex, "TransferAmountCannotBeZero");
     }
 
+    try {
+      await vault.transfer(staker, web3.utils.toWei("1"), { from: staker });
+      assert(false, "cannot transfer to self");
+    } catch (ex) {
+      assertVMException(ex, "CannotTransferToSelf");
+    }
+
     await vault.approve(staker2, web3.utils.toWei("1"), { from: staker });
 
     tx = await vault.transferFrom(staker, staker2, web3.utils.toWei("1"), { from: staker2 });

--- a/test/hatvaults.js
+++ b/test/hatvaults.js
@@ -1542,12 +1542,6 @@ contract("HatVaults", (accounts) => {
     }
 
     await utils.increaseTime(7 * 24 * 3600);
-    try {
-      await vault.withdrawRequest({ from: staker });
-      assert(false, "there is already pending request");
-    } catch (ex) {
-      assertVMException(ex, "PendingWithdrawRequestExists");
-    }
 
     await vault.redeem(web3.utils.toWei("0.5"), staker, staker, { from: staker });
     assert.equal(await vault.withdrawEnableStartTime(staker), 0);
@@ -1563,20 +1557,9 @@ contract("HatVaults", (accounts) => {
     assert.equal(await vault.withdrawEnableStartTime(staker), 0);
     await vault.deposit(web3.utils.toWei("1"), staker, { from: staker });
     await vault.withdrawRequest({ from: staker });
-    try {
-      await vault.withdrawRequest({ from: staker });
-      assert(false, "there is already pending request");
-    } catch (ex) {
-      assertVMException(ex, "PendingWithdrawRequestExists");
-    }
-    await utils.increaseTime(7 * 24 * 3600);
-    try {
-      await vault.withdrawRequest({ from: staker });
-      assert(false, "there is already pending request");
-    } catch (ex) {
-      assertVMException(ex, "PendingWithdrawRequestExists");
-    }
-    await utils.increaseTime(7 * 24 * 3600);
+
+    await utils.increaseTime(14 * 24 * 3600);
+
     //request is now expired so can request again.
     await vault.withdrawRequest({ from: staker });
   });

--- a/test/hatvaults.js
+++ b/test/hatvaults.js
@@ -1079,7 +1079,7 @@ contract("HatVaults", (accounts) => {
       await vault.mint(0, staker, { from: staker });
       assert(false, "cannot deposit 0");
     } catch (ex) {
-      assertVMException(ex, "TransferAmountCannotBeZero");
+      assertVMException(ex, "AmountCannotBeZero");
     }
 
     await vault.deposit(1, staker, { from: staker });
@@ -1090,7 +1090,7 @@ contract("HatVaults", (accounts) => {
       await vault.deposit(1, staker, { from: staker });
       assert(false, "cannot deposit amount too low for 1 share");
     } catch (ex) {
-      assertVMException(ex, "TransferAmountCannotBeZero");
+      assertVMException(ex, "AmountCannotBeZero");
     }
   });
 
@@ -3766,7 +3766,7 @@ it("getVaultReward - no vault updates will retrun 0 ", async () => {
       await vault.transferFrom(staker, staker2, 0, { from: staker2 });
       assert(false, "transfer amount cannot be 0");
     } catch (ex) {
-      assertVMException(ex, "TransferAmountCannotBeZero");
+      assertVMException(ex, "AmountCannotBeZero");
     }
 
     try {

--- a/test/hatvaults.js
+++ b/test/hatvaults.js
@@ -1079,7 +1079,7 @@ contract("HatVaults", (accounts) => {
       await vault.mint(0, staker, { from: staker });
       assert(false, "cannot deposit 0");
     } catch (ex) {
-      assertVMException(ex, "AmountToDepositIsZero");
+      assertVMException(ex, "TransferAmountCannotBeZero");
     }
 
     await vault.deposit(1, staker, { from: staker });
@@ -1090,7 +1090,7 @@ contract("HatVaults", (accounts) => {
       await vault.deposit(1, staker, { from: staker });
       assert(false, "cannot deposit amount too low for 1 share");
     } catch (ex) {
-      assertVMException(ex, "AmountToDepositIsZero");
+      assertVMException(ex, "TransferAmountCannotBeZero");
     }
   });
 

--- a/test/hatvaults.js
+++ b/test/hatvaults.js
@@ -3761,6 +3761,14 @@ it("getVaultReward - no vault updates will retrun 0 ", async () => {
     } catch (ex) {
       assertVMException(ex, "ERC20: insufficient allowance");
     }
+
+    try {
+      await vault.transferFrom(staker, staker2, 0, { from: staker2 });
+      assert(false, "transfer amount cannot be 0");
+    } catch (ex) {
+      assertVMException(ex, "TransferAmountCannotBeZero");
+    }
+
     await vault.approve(staker2, web3.utils.toWei("1"), { from: staker });
 
     tx = await vault.transferFrom(staker, staker2, web3.utils.toWei("1"), { from: staker2 });

--- a/test/hatvaults.js
+++ b/test/hatvaults.js
@@ -1673,6 +1673,16 @@ contract("HatVaults", (accounts) => {
       (await vault.maxWithdraw(staker)),
       web3.utils.toWei("0.98")
     );
+
+    assert.equal(
+      (await vault.previewWithdraw(web3.utils.toWei("0.98"))),
+      web3.utils.toWei("1")
+    );
+
+    assert.equal(
+      (await vault.previewRedeem(web3.utils.toWei("1"))),
+      web3.utils.toWei("0.98")
+    );
  
     await safeWithdraw(vault, web3.utils.toWei("0.98"), staker);
 


### PR DESCRIPTION
https://github.com/hats-finance/hats-contracts/issues/365

adam's comments:
1) this check: https://github.com/hats-finance/hats-contracts/blob/1272ef58df5d65fcc8d4cddbb23772cd4a6a5cf3/contracts/HATVault.sol#L498 can be bypassed by doing a zero token transfer, which will always succeed and will reset withdrawEnableStartTime[from] to 0
see:
https://github.com/hats-finance/hats-contracts/blob/1272ef58df5d65fcc8d4cddbb23772cd4a6a5cf3/contracts/HATVault.sol#L725
-> suggests to remove the check in https://github.com/hats-finance/hats-contracts/blob/1272ef58df5d65fcc8d4cddbb23772cd4a6a5cf3/contracts/HATVault.sol#L498

2) these two intervals:
https://github.com/hats-finance/hats-contracts/blob/1272ef58df5d65fcc8d4cddbb23772cd4a6a5cf3/contracts/HATVault.sol#L714
and
https://github.com/hats-finance/hats-contracts/blob/1272ef58df5d65fcc8d4cddbb23772cd4a6a5cf3/contracts/HATVault.sol#L763

overlap, meaning if the block timestamp is just right, you can receive shares and send them in the same block. Not sure if it's exploitable, but should be fixed.

-> change `<=` to `<` in https://github.com/hats-finance/hats-contracts/blob/1272ef58df5d65fcc8d4cddbb23772cd4a6a5cf3/contracts/HATVault.sol#L763

3) transfer of shares with the same to and from will lead to weird behavior due to the commitUserBalance calls, most likely ending in an underflow error, but might be even exploitable if rounding issues are exploited

-> fixed by fixing point 2

4) A user can call HATVault.transferFrom with 0 amount and arbitrary from which will always pass. This will lead to withdrawEnableStartTime[from] being set to 0. This basically allows anybody to block all transactions of any address.

-> add check in `_beforeTokenTransfer`

5) HATVault.withdraw is confusing and I'm not entierely sure whether it's correct. Especially rounding up when converting to assets here seems dubious. https://github.com/hats-finance/hats-contracts/blob/1272ef58df5d65fcc8d4cddbb23772cd4a6a5cf3/contracts/HATVault.sol#L532
Instead of the back and forth conversion, I'd recommend a version of calculating fee that's more easy to reason about.


    /** @notice See {IHATVault-withdraw}. */ 
    function withdraw(uint256 assets, address receiver, address owner)  
        public override(IHATVault, ERC4626Upgradeable) virtual returns (uint256) { 
        uint256 shares = previewWithdraw(assets); 
        uint256 fee = assets * HUNDRED_PERCENT / (HUNDRED_PERCENT - withdrawalFee) - assets; 
        _withdraw(_msgSender(), receiver, owner, assets, shares, fee); 
        return shares; 
    }
