### PR TITLE
Add HATPaymentSplitter contract

### DIFF
--- a/contracts/HATPaymentSplitter.sol
+++ b/contracts/HATPaymentSplitter.sol
@@ -12,7 +12,6 @@ contract HATPaymentSplitter is PaymentSplitterUpgradeable {
         _disableInitializers();
     }
 
-    // solhint-disable-next-line no-empty-blocks
     function initialize(address[] memory _payees, uint256[] memory _shares) external initializer {
         __PaymentSplitter_init(_payees, _shares);
     }

--- a/contracts/HATPaymentSplitter.sol
+++ b/contracts/HATPaymentSplitter.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+// Disclaimer https://github.com/hats-finance/hats-contracts/blob/main/DISCLAIMER.md
+
+pragma solidity 0.8.16;
+
+import "@openzeppelin/contracts/finance/PaymentSplitter.sol";
+import "./tokenlock/ITokenLock.sol";
+
+contract HATPaymentSplitter is PaymentSplitter {
+    
+    // Only a shareholder can make the call
+    error Unauthorized();
+
+    modifier onlyShareholder() {
+        if (shares(msg.sender) == 0) {
+            revert Unauthorized();
+        }
+        _;
+    }
+
+    // solhint-disable-next-line no-empty-blocks
+    constructor (address[] memory payees, uint256[] memory shares_) payable PaymentSplitter(payees, shares_) {}
+
+    /**
+     * @notice Releases tokens from a tokenlock contract
+     * @param _tokenLock The tokenlock to release from
+     */
+    function releaseFromTokenLock(ITokenLock _tokenLock) external onlyShareholder {
+        _tokenLock.release();
+    }
+
+    /**
+     * @notice Withdraws surplus, unmanaged tokens from a tokenlock contract
+     * @param _tokenLock The tokenlock to withdraw surplus from
+     * @param _amount Amount of tokens to withdraw
+     */
+    function withdrawSurplusFromTokenLock(ITokenLock _tokenLock, uint256 _amount) external onlyShareholder {
+        _tokenLock.withdrawSurplus(_amount);
+    }
+
+    /**
+     * @notice Sweeps out accidentally sent tokens from a tokenlock contract
+     * @param _tokenLock The tokenlock to call sweepToken on
+     * @param _token Address of token to sweep
+     */
+    function sweepTokenFromTokenLock(ITokenLock _tokenLock, IERC20 _token) external onlyShareholder {
+        _tokenLock.sweepToken(_token);
+    }
+
+
+}

--- a/contracts/HATPaymentSplitter.sol
+++ b/contracts/HATPaymentSplitter.sol
@@ -7,16 +7,6 @@ import "@openzeppelin/contracts/finance/PaymentSplitter.sol";
 import "./tokenlock/ITokenLock.sol";
 
 contract HATPaymentSplitter is PaymentSplitter {
-    
-    // Only a shareholder can make the call
-    error Unauthorized();
-
-    modifier onlyShareholder() {
-        if (shares(msg.sender) == 0) {
-            revert Unauthorized();
-        }
-        _;
-    }
 
     // solhint-disable-next-line no-empty-blocks
     constructor (address[] memory payees, uint256[] memory shares_) payable PaymentSplitter(payees, shares_) {}
@@ -25,7 +15,7 @@ contract HATPaymentSplitter is PaymentSplitter {
      * @notice Releases tokens from a tokenlock contract
      * @param _tokenLock The tokenlock to release from
      */
-    function releaseFromTokenLock(ITokenLock _tokenLock) external onlyShareholder {
+    function releaseFromTokenLock(ITokenLock _tokenLock) external {
         _tokenLock.release();
     }
 
@@ -34,7 +24,7 @@ contract HATPaymentSplitter is PaymentSplitter {
      * @param _tokenLock The tokenlock to withdraw surplus from
      * @param _amount Amount of tokens to withdraw
      */
-    function withdrawSurplusFromTokenLock(ITokenLock _tokenLock, uint256 _amount) external onlyShareholder {
+    function withdrawSurplusFromTokenLock(ITokenLock _tokenLock, uint256 _amount) external {
         _tokenLock.withdrawSurplus(_amount);
     }
 
@@ -43,7 +33,7 @@ contract HATPaymentSplitter is PaymentSplitter {
      * @param _tokenLock The tokenlock to call sweepToken on
      * @param _token Address of token to sweep
      */
-    function sweepTokenFromTokenLock(ITokenLock _tokenLock, IERC20 _token) external onlyShareholder {
+    function sweepTokenFromTokenLock(ITokenLock _tokenLock, IERC20 _token) external {
         _tokenLock.sweepToken(_token);
     }
 

--- a/contracts/HATPaymentSplitter.sol
+++ b/contracts/HATPaymentSplitter.sol
@@ -3,13 +3,19 @@
 
 pragma solidity 0.8.16;
 
-import "@openzeppelin/contracts/finance/PaymentSplitter.sol";
+import "@openzeppelin/contracts-upgradeable/finance/PaymentSplitterUpgradeable.sol";
 import "./tokenlock/ITokenLock.sol";
 
-contract HATPaymentSplitter is PaymentSplitter {
+contract HATPaymentSplitter is PaymentSplitterUpgradeable {
+
+    constructor () {
+        _disableInitializers();
+    }
 
     // solhint-disable-next-line no-empty-blocks
-    constructor (address[] memory payees, uint256[] memory shares_) payable PaymentSplitter(payees, shares_) {}
+    function initialize(address[] memory _payees, uint256[] memory _shares) external initializer {
+        __PaymentSplitter_init(_payees, _shares);
+    }
 
     /**
      * @notice Releases tokens from a tokenlock contract

--- a/contracts/HATPaymentSplitterFactory.sol
+++ b/contracts/HATPaymentSplitterFactory.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+// Disclaimer https://github.com/hats-finance/hats-contracts/blob/main/DISCLAIMER.md
+
+pragma solidity 0.8.16;
+
+import "@openzeppelin/contracts/proxy/Clones.sol";
+import "./HATPaymentSplitter.sol";
+
+contract HATPaymentSplitterFactory {
+    address public immutable implementation;
+    event HATPaymentSplitterCreated(address indexed _hatPaymentSplitter);
+
+    constructor (address _implementation) {
+        implementation = _implementation;
+    }
+
+    function createHATPaymentSplitter(address[] memory _payees, uint256[] memory _shares) external returns (address result) {
+        result = Clones.clone(implementation);
+        HATPaymentSplitter(payable(result)).initialize(_payees, _shares);
+        emit HATPaymentSplitterCreated(result);
+    }
+}

--- a/contracts/HATPaymentSplitterFactory.sol
+++ b/contracts/HATPaymentSplitterFactory.sol
@@ -8,6 +8,7 @@ import "./HATPaymentSplitter.sol";
 
 contract HATPaymentSplitterFactory {
     address public immutable implementation;
+    mapping(address => uint256) public nonce;
     event HATPaymentSplitterCreated(address indexed _hatPaymentSplitter);
 
     constructor (address _implementation) {
@@ -15,8 +16,16 @@ contract HATPaymentSplitterFactory {
     }
 
     function createHATPaymentSplitter(address[] memory _payees, uint256[] memory _shares) external returns (address result) {
-        result = Clones.clone(implementation);
+        result = Clones.cloneDeterministic(implementation, keccak256(abi.encodePacked(msg.sender, nonce[msg.sender]++)));
         HATPaymentSplitter(payable(result)).initialize(_payees, _shares);
         emit HATPaymentSplitterCreated(result);
+    }
+
+    function predictNextSplitterAddress(address _deployer) external view returns (address) {
+        return predictSplitterAddress(nonce[_deployer], _deployer);
+    }
+
+    function predictSplitterAddress(uint256 _nonce, address _deployer) public view returns (address) {
+        return Clones.predictDeterministicAddress(implementation, keccak256(abi.encodePacked(_deployer, _nonce)));
     }
 }

--- a/contracts/tokenlock/ITokenLock.sol
+++ b/contracts/tokenlock/ITokenLock.sol
@@ -3,6 +3,8 @@
 pragma solidity 0.8.16;
 pragma experimental ABIEncoderV2;
 
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
 interface ITokenLock {
     enum Revocability { NotSet, Enabled, Disabled }
 
@@ -11,6 +13,8 @@ interface ITokenLock {
     function release() external;
 
     function withdrawSurplus(uint256 _amount) external;
+
+    function sweepToken(IERC20 _token) external;
 
     function revoke() external;
 

--- a/contracts/tokenlock/TokenLock.sol
+++ b/contracts/tokenlock/TokenLock.sol
@@ -2,7 +2,6 @@
 
 pragma solidity 0.8.16;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
@@ -174,9 +173,11 @@ abstract contract TokenLock is Ownable, ITokenLock {
         emit TokensRevoked(beneficiary, unvestedAmount);
     }
 
-    /// @dev sweeps out accidentally sent tokens
-    /// @param _token Address of token to sweep
-    function sweepToken(IERC20 _token) external {
+    /**
+     * @notice Sweeps out accidentally sent tokens
+     * @param _token Address of token to sweep
+     */
+    function sweepToken(IERC20 _token) external override {
         address sweeper = owner() == address(0) ? beneficiary : owner();
         require(msg.sender == sweeper, "!auth");
         require(_token != token, "cannot sweep vested token");

--- a/docs/dodoc/HATPaymentSplitter.md
+++ b/docs/dodoc/HATPaymentSplitter.md
@@ -358,17 +358,3 @@ event PaymentReleased(address to, uint256 amount)
 
 
 
-## Errors
-
-### Unauthorized
-
-```solidity
-error Unauthorized()
-```
-
-
-
-
-
-
-

--- a/docs/dodoc/HATPaymentSplitter.md
+++ b/docs/dodoc/HATPaymentSplitter.md
@@ -10,6 +10,23 @@
 
 ## Methods
 
+### initialize
+
+```solidity
+function initialize(address[] _payees, uint256[] _shares) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _payees | address[] | undefined |
+| _shares | uint256[] | undefined |
+
 ### payee
 
 ```solidity
@@ -57,7 +74,7 @@ function releasable(address account) external view returns (uint256)
 ### releasable
 
 ```solidity
-function releasable(contract IERC20 token, address account) external view returns (uint256)
+function releasable(contract IERC20Upgradeable token, address account) external view returns (uint256)
 ```
 
 
@@ -68,7 +85,7 @@ function releasable(contract IERC20 token, address account) external view return
 
 | Name | Type | Description |
 |---|---|---|
-| token | contract IERC20 | undefined |
+| token | contract IERC20Upgradeable | undefined |
 | account | address | undefined |
 
 #### Returns
@@ -96,7 +113,7 @@ function release(address payable account) external nonpayable
 ### release
 
 ```solidity
-function release(contract IERC20 token, address account) external nonpayable
+function release(contract IERC20Upgradeable token, address account) external nonpayable
 ```
 
 
@@ -107,7 +124,7 @@ function release(contract IERC20 token, address account) external nonpayable
 
 | Name | Type | Description |
 |---|---|---|
-| token | contract IERC20 | undefined |
+| token | contract IERC20Upgradeable | undefined |
 | account | address | undefined |
 
 ### releaseFromTokenLock
@@ -129,7 +146,7 @@ Releases tokens from a tokenlock contract
 ### released
 
 ```solidity
-function released(contract IERC20 token, address account) external view returns (uint256)
+function released(contract IERC20Upgradeable token, address account) external view returns (uint256)
 ```
 
 
@@ -140,7 +157,7 @@ function released(contract IERC20 token, address account) external view returns 
 
 | Name | Type | Description |
 |---|---|---|
-| token | contract IERC20 | undefined |
+| token | contract IERC20Upgradeable | undefined |
 | account | address | undefined |
 
 #### Returns
@@ -213,7 +230,7 @@ Sweeps out accidentally sent tokens from a tokenlock contract
 ### totalReleased
 
 ```solidity
-function totalReleased(contract IERC20 token) external view returns (uint256)
+function totalReleased(contract IERC20Upgradeable token) external view returns (uint256)
 ```
 
 
@@ -224,7 +241,7 @@ function totalReleased(contract IERC20 token) external view returns (uint256)
 
 | Name | Type | Description |
 |---|---|---|
-| token | contract IERC20 | undefined |
+| token | contract IERC20Upgradeable | undefined |
 
 #### Returns
 
@@ -290,7 +307,7 @@ Withdraws surplus, unmanaged tokens from a tokenlock contract
 ### ERC20PaymentReleased
 
 ```solidity
-event ERC20PaymentReleased(contract IERC20 indexed token, address to, uint256 amount)
+event ERC20PaymentReleased(contract IERC20Upgradeable indexed token, address to, uint256 amount)
 ```
 
 
@@ -301,9 +318,25 @@ event ERC20PaymentReleased(contract IERC20 indexed token, address to, uint256 am
 
 | Name | Type | Description |
 |---|---|---|
-| token `indexed` | contract IERC20 | undefined |
+| token `indexed` | contract IERC20Upgradeable | undefined |
 | to  | address | undefined |
 | amount  | uint256 | undefined |
+
+### Initialized
+
+```solidity
+event Initialized(uint8 version)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| version  | uint8 | undefined |
 
 ### PayeeAdded
 

--- a/docs/dodoc/HATPaymentSplitter.md
+++ b/docs/dodoc/HATPaymentSplitter.md
@@ -1,0 +1,374 @@
+# HATPaymentSplitter
+
+
+
+
+
+
+
+
+
+## Methods
+
+### payee
+
+```solidity
+function payee(uint256 index) external view returns (address)
+```
+
+
+
+*Getter for the address of the payee number `index`.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| index | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### releasable
+
+```solidity
+function releasable(address account) external view returns (uint256)
+```
+
+
+
+*Getter for the amount of payee&#39;s releasable Ether.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### releasable
+
+```solidity
+function releasable(contract IERC20 token, address account) external view returns (uint256)
+```
+
+
+
+*Getter for the amount of payee&#39;s releasable `token` tokens. `token` should be the address of an IERC20 contract.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| token | contract IERC20 | undefined |
+| account | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### release
+
+```solidity
+function release(address payable account) external nonpayable
+```
+
+
+
+*Triggers a transfer to `account` of the amount of Ether they are owed, according to their percentage of the total shares and their previous withdrawals.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account | address payable | undefined |
+
+### release
+
+```solidity
+function release(contract IERC20 token, address account) external nonpayable
+```
+
+
+
+*Triggers a transfer to `account` of the amount of `token` tokens they are owed, according to their percentage of the total shares and their previous withdrawals. `token` must be the address of an IERC20 contract.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| token | contract IERC20 | undefined |
+| account | address | undefined |
+
+### releaseFromTokenLock
+
+```solidity
+function releaseFromTokenLock(contract ITokenLock _tokenLock) external nonpayable
+```
+
+Releases tokens from a tokenlock contract
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _tokenLock | contract ITokenLock | The tokenlock to release from |
+
+### released
+
+```solidity
+function released(contract IERC20 token, address account) external view returns (uint256)
+```
+
+
+
+*Getter for the amount of `token` tokens already released to a payee. `token` should be the address of an IERC20 contract.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| token | contract IERC20 | undefined |
+| account | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### released
+
+```solidity
+function released(address account) external view returns (uint256)
+```
+
+
+
+*Getter for the amount of Ether already released to a payee.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### shares
+
+```solidity
+function shares(address account) external view returns (uint256)
+```
+
+
+
+*Getter for the amount of shares held by an account.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### sweepTokenFromTokenLock
+
+```solidity
+function sweepTokenFromTokenLock(contract ITokenLock _tokenLock, contract IERC20 _token) external nonpayable
+```
+
+Sweeps out accidentally sent tokens from a tokenlock contract
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _tokenLock | contract ITokenLock | The tokenlock to call sweepToken on |
+| _token | contract IERC20 | Address of token to sweep |
+
+### totalReleased
+
+```solidity
+function totalReleased(contract IERC20 token) external view returns (uint256)
+```
+
+
+
+*Getter for the total amount of `token` already released. `token` should be the address of an IERC20 contract.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| token | contract IERC20 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### totalReleased
+
+```solidity
+function totalReleased() external view returns (uint256)
+```
+
+
+
+*Getter for the total amount of Ether already released.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### totalShares
+
+```solidity
+function totalShares() external view returns (uint256)
+```
+
+
+
+*Getter for the total shares held by payees.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### withdrawSurplusFromTokenLock
+
+```solidity
+function withdrawSurplusFromTokenLock(contract ITokenLock _tokenLock, uint256 _amount) external nonpayable
+```
+
+Withdraws surplus, unmanaged tokens from a tokenlock contract
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _tokenLock | contract ITokenLock | The tokenlock to withdraw surplus from |
+| _amount | uint256 | Amount of tokens to withdraw |
+
+
+
+## Events
+
+### ERC20PaymentReleased
+
+```solidity
+event ERC20PaymentReleased(contract IERC20 indexed token, address to, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| token `indexed` | contract IERC20 | undefined |
+| to  | address | undefined |
+| amount  | uint256 | undefined |
+
+### PayeeAdded
+
+```solidity
+event PayeeAdded(address account, uint256 shares)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account  | address | undefined |
+| shares  | uint256 | undefined |
+
+### PaymentReceived
+
+```solidity
+event PaymentReceived(address from, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| from  | address | undefined |
+| amount  | uint256 | undefined |
+
+### PaymentReleased
+
+```solidity
+event PaymentReleased(address to, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| to  | address | undefined |
+| amount  | uint256 | undefined |
+
+
+
+## Errors
+
+### Unauthorized
+
+```solidity
+error Unauthorized()
+```
+
+
+
+
+
+
+

--- a/docs/dodoc/HATPaymentSplitterFactory.md
+++ b/docs/dodoc/HATPaymentSplitterFactory.md
@@ -50,6 +50,73 @@ function implementation() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
+### nonce
+
+```solidity
+function nonce(address) external view returns (uint256)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### predictNextSplitterAddress
+
+```solidity
+function predictNextSplitterAddress(address _deployer) external view returns (address)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _deployer | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### predictSplitterAddress
+
+```solidity
+function predictSplitterAddress(uint256 _nonce, address _deployer) external view returns (address)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _nonce | uint256 | undefined |
+| _deployer | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
 
 
 ## Events

--- a/docs/dodoc/HATPaymentSplitterFactory.md
+++ b/docs/dodoc/HATPaymentSplitterFactory.md
@@ -1,0 +1,74 @@
+# HATPaymentSplitterFactory
+
+
+
+
+
+
+
+
+
+## Methods
+
+### createHATPaymentSplitter
+
+```solidity
+function createHATPaymentSplitter(address[] _payees, uint256[] _shares) external nonpayable returns (address result)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _payees | address[] | undefined |
+| _shares | uint256[] | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| result | address | undefined |
+
+### implementation
+
+```solidity
+function implementation() external view returns (address)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+
+
+## Events
+
+### HATPaymentSplitterCreated
+
+```solidity
+event HATPaymentSplitterCreated(address indexed _hatPaymentSplitter)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _hatPaymentSplitter `indexed` | address | undefined |
+
+
+

--- a/docs/dodoc/elin/contracts-upgradeable/finance/PaymentSplitterUpgradeable.md
+++ b/docs/dodoc/elin/contracts-upgradeable/finance/PaymentSplitterUpgradeable.md
@@ -1,4 +1,4 @@
-# PaymentSplitter
+# PaymentSplitterUpgradeable
 
 
 
@@ -57,7 +57,7 @@ function releasable(address account) external view returns (uint256)
 ### releasable
 
 ```solidity
-function releasable(contract IERC20 token, address account) external view returns (uint256)
+function releasable(contract IERC20Upgradeable token, address account) external view returns (uint256)
 ```
 
 
@@ -68,7 +68,7 @@ function releasable(contract IERC20 token, address account) external view return
 
 | Name | Type | Description |
 |---|---|---|
-| token | contract IERC20 | undefined |
+| token | contract IERC20Upgradeable | undefined |
 | account | address | undefined |
 
 #### Returns
@@ -96,7 +96,7 @@ function release(address payable account) external nonpayable
 ### release
 
 ```solidity
-function release(contract IERC20 token, address account) external nonpayable
+function release(contract IERC20Upgradeable token, address account) external nonpayable
 ```
 
 
@@ -107,13 +107,13 @@ function release(contract IERC20 token, address account) external nonpayable
 
 | Name | Type | Description |
 |---|---|---|
-| token | contract IERC20 | undefined |
+| token | contract IERC20Upgradeable | undefined |
 | account | address | undefined |
 
 ### released
 
 ```solidity
-function released(contract IERC20 token, address account) external view returns (uint256)
+function released(contract IERC20Upgradeable token, address account) external view returns (uint256)
 ```
 
 
@@ -124,7 +124,7 @@ function released(contract IERC20 token, address account) external view returns 
 
 | Name | Type | Description |
 |---|---|---|
-| token | contract IERC20 | undefined |
+| token | contract IERC20Upgradeable | undefined |
 | account | address | undefined |
 
 #### Returns
@@ -180,7 +180,7 @@ function shares(address account) external view returns (uint256)
 ### totalReleased
 
 ```solidity
-function totalReleased(contract IERC20 token) external view returns (uint256)
+function totalReleased(contract IERC20Upgradeable token) external view returns (uint256)
 ```
 
 
@@ -191,7 +191,7 @@ function totalReleased(contract IERC20 token) external view returns (uint256)
 
 | Name | Type | Description |
 |---|---|---|
-| token | contract IERC20 | undefined |
+| token | contract IERC20Upgradeable | undefined |
 
 #### Returns
 
@@ -240,7 +240,7 @@ function totalShares() external view returns (uint256)
 ### ERC20PaymentReleased
 
 ```solidity
-event ERC20PaymentReleased(contract IERC20 indexed token, address to, uint256 amount)
+event ERC20PaymentReleased(contract IERC20Upgradeable indexed token, address to, uint256 amount)
 ```
 
 
@@ -251,9 +251,25 @@ event ERC20PaymentReleased(contract IERC20 indexed token, address to, uint256 am
 
 | Name | Type | Description |
 |---|---|---|
-| token `indexed` | contract IERC20 | undefined |
+| token `indexed` | contract IERC20Upgradeable | undefined |
 | to  | address | undefined |
 | amount  | uint256 | undefined |
+
+### Initialized
+
+```solidity
+event Initialized(uint8 version)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| version  | uint8 | undefined |
 
 ### PayeeAdded
 

--- a/docs/dodoc/elin/contracts/finance/PaymentSplitter.md
+++ b/docs/dodoc/elin/contracts/finance/PaymentSplitter.md
@@ -1,0 +1,310 @@
+# PaymentSplitter
+
+
+
+> PaymentSplitter
+
+
+
+*This contract allows to split Ether payments among a group of accounts. The sender does not need to be aware that the Ether will be split in this way, since it is handled transparently by the contract. The split can be in equal parts or in any other arbitrary proportion. The way this is specified is by assigning each account to a number of shares. Of all the Ether that this contract receives, each account will then be able to claim an amount proportional to the percentage of total shares they were assigned. The distribution of shares is set at the time of contract deployment and can&#39;t be updated thereafter. `PaymentSplitter` follows a _pull payment_ model. This means that payments are not automatically forwarded to the accounts but kept in this contract, and the actual transfer is triggered as a separate step by calling the {release} function. NOTE: This contract assumes that ERC20 tokens will behave similarly to native tokens (Ether). Rebasing tokens, and tokens that apply fees during transfers, are likely to not be supported as expected. If in doubt, we encourage you to run tests before sending real value to this contract.*
+
+## Methods
+
+### payee
+
+```solidity
+function payee(uint256 index) external view returns (address)
+```
+
+
+
+*Getter for the address of the payee number `index`.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| index | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### releasable
+
+```solidity
+function releasable(address account) external view returns (uint256)
+```
+
+
+
+*Getter for the amount of payee&#39;s releasable Ether.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### releasable
+
+```solidity
+function releasable(contract IERC20 token, address account) external view returns (uint256)
+```
+
+
+
+*Getter for the amount of payee&#39;s releasable `token` tokens. `token` should be the address of an IERC20 contract.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| token | contract IERC20 | undefined |
+| account | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### release
+
+```solidity
+function release(address payable account) external nonpayable
+```
+
+
+
+*Triggers a transfer to `account` of the amount of Ether they are owed, according to their percentage of the total shares and their previous withdrawals.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account | address payable | undefined |
+
+### release
+
+```solidity
+function release(contract IERC20 token, address account) external nonpayable
+```
+
+
+
+*Triggers a transfer to `account` of the amount of `token` tokens they are owed, according to their percentage of the total shares and their previous withdrawals. `token` must be the address of an IERC20 contract.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| token | contract IERC20 | undefined |
+| account | address | undefined |
+
+### released
+
+```solidity
+function released(contract IERC20 token, address account) external view returns (uint256)
+```
+
+
+
+*Getter for the amount of `token` tokens already released to a payee. `token` should be the address of an IERC20 contract.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| token | contract IERC20 | undefined |
+| account | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### released
+
+```solidity
+function released(address account) external view returns (uint256)
+```
+
+
+
+*Getter for the amount of Ether already released to a payee.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### shares
+
+```solidity
+function shares(address account) external view returns (uint256)
+```
+
+
+
+*Getter for the amount of shares held by an account.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### totalReleased
+
+```solidity
+function totalReleased(contract IERC20 token) external view returns (uint256)
+```
+
+
+
+*Getter for the total amount of `token` already released. `token` should be the address of an IERC20 contract.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| token | contract IERC20 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### totalReleased
+
+```solidity
+function totalReleased() external view returns (uint256)
+```
+
+
+
+*Getter for the total amount of Ether already released.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### totalShares
+
+```solidity
+function totalShares() external view returns (uint256)
+```
+
+
+
+*Getter for the total shares held by payees.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+
+
+## Events
+
+### ERC20PaymentReleased
+
+```solidity
+event ERC20PaymentReleased(contract IERC20 indexed token, address to, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| token `indexed` | contract IERC20 | undefined |
+| to  | address | undefined |
+| amount  | uint256 | undefined |
+
+### PayeeAdded
+
+```solidity
+event PayeeAdded(address account, uint256 shares)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account  | address | undefined |
+| shares  | uint256 | undefined |
+
+### PaymentReceived
+
+```solidity
+event PaymentReceived(address from, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| from  | address | undefined |
+| amount  | uint256 | undefined |
+
+### PaymentReleased
+
+```solidity
+event PaymentReleased(address to, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| to  | address | undefined |
+| amount  | uint256 | undefined |
+
+
+

--- a/docs/dodoc/tokenlock/HATTokenLock.md
+++ b/docs/dodoc/tokenlock/HATTokenLock.md
@@ -537,9 +537,9 @@ Gets surplus amount in the contract based on outstanding amount to release
 function sweepToken(contract IERC20 _token) external nonpayable
 ```
 
+Sweeps out accidentally sent tokens
 
 
-*sweeps out accidentally sent tokens*
 
 #### Parameters
 

--- a/docs/dodoc/tokenlock/ITokenLock.md
+++ b/docs/dodoc/tokenlock/ITokenLock.md
@@ -219,6 +219,22 @@ function surplusAmount() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined |
 
+### sweepToken
+
+```solidity
+function sweepToken(contract IERC20 _token) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _token | contract IERC20 | undefined |
+
 ### totalOutstandingAmount
 
 ```solidity

--- a/docs/dodoc/tokenlock/TokenLock.md
+++ b/docs/dodoc/tokenlock/TokenLock.md
@@ -478,9 +478,9 @@ Gets surplus amount in the contract based on outstanding amount to release
 function sweepToken(contract IERC20 _token) external nonpayable
 ```
 
+Sweeps out accidentally sent tokens
 
 
-*sweeps out accidentally sent tokens*
 
 #### Parameters
 

--- a/test/hatvaults.js
+++ b/test/hatvaults.js
@@ -5130,6 +5130,13 @@ it("getVaultReward - no vault updates will return 0 ", async () => {
     assert.equal(tx.logs[0].event, "HATPaymentSplitterCreated");
     let hatPaymentSplitter = await HATPaymentSplitter.at(tx.logs[0].args._hatPaymentSplitter);
 
+    try {
+      await hatPaymentSplitter.initialize([accounts[2], accounts[3]], [5000, 5000]);
+      assert(false, "already initialized");
+    } catch (ex) {
+      assertVMException(ex, "Initializable: contract is already initialized");
+    }
+
     await advanceToSafetyPeriod();
     tx = await vault.submitClaim(
       hatPaymentSplitter.address,

--- a/test/hatvaults.js
+++ b/test/hatvaults.js
@@ -1,6 +1,7 @@
 const HATVault = artifacts.require("./HATVault.sol");
 const HATVaultsRegistry = artifacts.require("./HATVaultsRegistry.sol");
 const HATTokenMock = artifacts.require("./HATTokenMock.sol");
+const HATPaymentSplitter = artifacts.require("./HATPaymentSplitter.sol");
 const ERC20Mock = artifacts.require("./ERC20Mock.sol");
 const UniSwapV3RouterMock = artifacts.require("./UniSwapV3RouterMock.sol");
 const TokenLockFactory = artifacts.require("./TokenLockFactory.sol");
@@ -5105,6 +5106,163 @@ it("getVaultReward - no vault updates will return 0 ", async () => {
       tx.logs[1].args._amountSent.toString(),
       expectedHackerReward.toString()
     );
+  });
+
+  it("hatpaymentsplitter withdraw from tokenlock", async () => {
+    await setUpGlobalVars(accounts, 0, 8000, [8000, 2000, 0], [550, 450]);
+    var staker = accounts[4];
+    await stakingToken.approve(vault.address, web3.utils.toWei("1"), {
+      from: staker,
+    });
+    await stakingToken.mint(staker, web3.utils.toWei("1"));
+    await vault.deposit(web3.utils.toWei("1"), staker, { from: staker });
+    assert.equal(await hatToken.balanceOf(staker), 0);
+
+    let hatPaymentSplitter = await HATPaymentSplitter.new(
+      [accounts[2], accounts[3]],
+      [5000, 5000]
+    );
+
+    await advanceToSafetyPeriod();
+    let tx = await vault.submitClaim(
+      hatPaymentSplitter.address,
+      8000,
+      "description hash",
+      {
+        from: accounts[1],
+      }
+    );
+
+    let claimId = tx.logs[0].args._claimId;
+    await utils.increaseTime(60 * 60 * 24);
+    await vault.approveClaim(claimId, 8000);
+
+    let path = ethers.utils.solidityPack(
+      ["address", "uint24", "address", "uint24", "address"],
+      [stakingToken.address, 0, utils.NULL_ADDRESS, 0, hatToken.address]
+    );
+    let amountForHackersHatRewards = await hatVaultsRegistry.hackersHatReward(
+      stakingToken.address,
+      hatPaymentSplitter.address
+    );
+    let amount = amountForHackersHatRewards.add(await hatVaultsRegistry.governanceHatReward(stakingToken.address));
+    let payload = ISwapRouter.encodeFunctionData("exactInput", [
+      [path, hatVaultsRegistry.address, 0, amount.toString(), 0],
+    ]);
+    tx = await hatVaultsRegistry.swapAndSend(
+      stakingToken.address, 
+      [hatPaymentSplitter.address],
+      0,
+      router.address,
+      payload
+    );
+
+    var vestingTokenLock = await HATTokenLock.at(tx.logs[1].args._tokenLock);
+
+    assert.equal(
+      (await hatToken.balanceOf(vestingTokenLock.address)).toString(),
+      tx.logs[1].args._amountSent.toString()
+    );
+    var expectedHackerReward = new web3.utils.BN(web3.utils.toWei("0.8"))
+      .mul(new web3.utils.BN(9))
+      .div(new web3.utils.BN(2))
+      .div(new web3.utils.BN(100));
+    assert.equal(
+      tx.logs[1].args._amountSent.toString(),
+      expectedHackerReward.toString()
+    );
+
+    await hatToken.setMinter(accounts[0], web3.utils.toWei("1"));
+    await hatToken.mint(vestingTokenLock.address, web3.utils.toWei("1"));
+
+    try {
+      await hatPaymentSplitter.withdrawSurplusFromTokenLock(vestingTokenLock.address, web3.utils.toWei("1"));
+      assert(false, "only shareholder");
+    } catch (ex) {
+      assertVMException(ex, "Unauthorized");
+    }
+
+    await hatPaymentSplitter.withdrawSurplusFromTokenLock(vestingTokenLock.address, web3.utils.toWei("1"), { from: accounts[3] });
+
+    assert.equal(
+      (await hatToken.balanceOf(hatPaymentSplitter.address)).toString(),
+      new web3.utils.BN(web3.utils.toWei("1")).toString()
+    );
+
+    let accidentToken = await ERC20Mock.new("Accident", "ACT");
+    await accidentToken.mint(vestingTokenLock.address, web3.utils.toWei("1"));
+
+    try {
+      await hatPaymentSplitter.sweepTokenFromTokenLock(vestingTokenLock.address, accidentToken.address);
+      assert(false, "only shareholder");
+    } catch (ex) {
+      assertVMException(ex, "Unauthorized");
+    }
+
+    await hatPaymentSplitter.sweepTokenFromTokenLock(vestingTokenLock.address, accidentToken.address, { from: accounts[2] });
+
+    assert.equal(
+      (await accidentToken.balanceOf(hatPaymentSplitter.address)).toString(),
+      web3.utils.toWei("1").toString()
+    );
+
+    try {
+      await hatPaymentSplitter.releaseFromTokenLock(vestingTokenLock.address);
+      assert(false, "only shareholder");
+    } catch (ex) {
+      assertVMException(ex, "Unauthorized");
+    }
+
+    await utils.increaseTime(60 * 60 * 60 * 24 * 90);
+
+    await hatPaymentSplitter.releaseFromTokenLock(vestingTokenLock.address, { from: accounts[2] });
+
+    assert.equal(
+      (await hatToken.balanceOf(hatPaymentSplitter.address)).toString(),
+      new web3.utils.BN(web3.utils.toWei("1")).add(expectedHackerReward).toString()
+    );
+
+    await hatPaymentSplitter.release(hatToken.address, accounts[2]);
+    await hatPaymentSplitter.release(hatToken.address, accounts[3]);
+
+    assert.equal(
+      (await hatToken.balanceOf(hatPaymentSplitter.address)).toString(),
+      "0"
+    );
+
+    assert.equal(
+      (await hatToken.balanceOf(accounts[2])).toString(),
+      new web3.utils.BN(web3.utils.toWei("1")).add(expectedHackerReward).div(new web3.utils.BN(2)).toString()
+    );
+
+    assert.equal(
+      (await hatToken.balanceOf(accounts[3])).toString(),
+      new web3.utils.BN(web3.utils.toWei("1")).add(expectedHackerReward).div(new web3.utils.BN(2)).toString()
+    );
+
+    assert.equal(
+      (await accidentToken.balanceOf(hatPaymentSplitter.address)).toString(),
+      new web3.utils.BN(web3.utils.toWei("1")).toString()
+    );
+
+    await hatPaymentSplitter.release(accidentToken.address, accounts[2]);
+    await hatPaymentSplitter.release(accidentToken.address, accounts[3]);
+
+    assert.equal(
+      (await accidentToken.balanceOf(hatPaymentSplitter.address)).toString(),
+      "0"
+    );
+
+    assert.equal(
+      (await accidentToken.balanceOf(accounts[3])).toString(),
+      new web3.utils.BN(web3.utils.toWei("0.5")).toString()
+    );
+
+    assert.equal(
+      (await accidentToken.balanceOf(accounts[3])).toString(),
+      new web3.utils.BN(web3.utils.toWei("0.5")).toString()
+    );
+    
   });
 
   it("swapAndSend with duplicate beneficiary", async () => {

--- a/test/hatvaults.js
+++ b/test/hatvaults.js
@@ -5175,13 +5175,6 @@ it("getVaultReward - no vault updates will return 0 ", async () => {
     await hatToken.setMinter(accounts[0], web3.utils.toWei("1"));
     await hatToken.mint(vestingTokenLock.address, web3.utils.toWei("1"));
 
-    try {
-      await hatPaymentSplitter.withdrawSurplusFromTokenLock(vestingTokenLock.address, web3.utils.toWei("1"));
-      assert(false, "only shareholder");
-    } catch (ex) {
-      assertVMException(ex, "Unauthorized");
-    }
-
     await hatPaymentSplitter.withdrawSurplusFromTokenLock(vestingTokenLock.address, web3.utils.toWei("1"), { from: accounts[3] });
 
     assert.equal(
@@ -5192,26 +5185,12 @@ it("getVaultReward - no vault updates will return 0 ", async () => {
     let accidentToken = await ERC20Mock.new("Accident", "ACT");
     await accidentToken.mint(vestingTokenLock.address, web3.utils.toWei("1"));
 
-    try {
-      await hatPaymentSplitter.sweepTokenFromTokenLock(vestingTokenLock.address, accidentToken.address);
-      assert(false, "only shareholder");
-    } catch (ex) {
-      assertVMException(ex, "Unauthorized");
-    }
-
     await hatPaymentSplitter.sweepTokenFromTokenLock(vestingTokenLock.address, accidentToken.address, { from: accounts[2] });
 
     assert.equal(
       (await accidentToken.balanceOf(hatPaymentSplitter.address)).toString(),
       web3.utils.toWei("1").toString()
     );
-
-    try {
-      await hatPaymentSplitter.releaseFromTokenLock(vestingTokenLock.address);
-      assert(false, "only shareholder");
-    } catch (ex) {
-      assertVMException(ex, "Unauthorized");
-    }
 
     await utils.increaseTime(60 * 60 * 60 * 24 * 90);
 


### PR DESCRIPTION
Adds a contract inheriting OZ's PaymentSplitter which can make calls necessary to interact with token locks.