### PR TITLE
Add 100% max bounty mode

### DIFF
--- a/contracts/HATVault.sol
+++ b/contracts/HATVault.sol
@@ -214,7 +214,7 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
             revert NotSafetyPeriod();
         if (_bountyPercentage > maxBounty)
             revert BountyPercentageHigherThanMaxBounty();
-        if (maxBounty == HUNDRED_PERCENT && _bountyPercentage != HUNDRED_PERCENT)
+        if (maxBounty == HUNDRED_PERCENT && (_bountyPercentage > MAX_BOUNTY_LIMIT && _bountyPercentage != HUNDRED_PERCENT)
             revert PayoutMustBeHundredPercent();
         claimId = keccak256(abi.encodePacked(address(this), ++nonce));
         activeClaim = Claim({

--- a/contracts/HATVault.sol
+++ b/contracts/HATVault.sol
@@ -214,7 +214,7 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
             revert NotSafetyPeriod();
         if (_bountyPercentage > maxBounty)
             revert BountyPercentageHigherThanMaxBounty();
-        if (maxBounty == HUNDRED_PERCENT && (_bountyPercentage > MAX_BOUNTY_LIMIT && _bountyPercentage != HUNDRED_PERCENT)
+        if (maxBounty == HUNDRED_PERCENT && _bountyPercentage > MAX_BOUNTY_LIMIT && _bountyPercentage != HUNDRED_PERCENT)
             revert PayoutMustBeHundredPercent();
         claimId = keccak256(abi.encodePacked(address(this), ++nonce));
         activeClaim = Claim({

--- a/contracts/interfaces/IHATVault.sol
+++ b/contracts/interfaces/IHATVault.sol
@@ -138,7 +138,7 @@ interface IHATVault is IERC4626Upgradeable {
     error VestingPeriodsCannotBeZero();
     // Vesting duration smaller than periods
     error VestingDurationSmallerThanPeriods();
-    // Max bounty cannot be more than `MAX_BOUNTY_LIMIT`
+    // Max bounty cannot be more than `MAX_BOUNTY_LIMIT` (unless if it is 100%)
     error MaxBountyCannotBeMoreThanMaxBountyLimit();
     // Committee bounty split cannot be more than `MAX_COMMITTEE_BOUNTY`
     error CommitteeBountyCannotBeMoreThanMax();
@@ -194,6 +194,10 @@ interface IHATVault is IERC4626Upgradeable {
     error RedeemSlippageProtection();
     // Cannot add the same reward controller more than once
     error DuplicatedRewardController();
+    // Must pay 100% when max bounty is set to 100%
+    error PayoutMustBeHundredPercent();
+    // Cannot unpasue deposits for a vault that was destroyed
+    error CannotUnpauseDestroyedVault();
 
 
     event SubmitClaim(
@@ -235,6 +239,7 @@ interface IHATVault is IERC4626Upgradeable {
         address indexed _beneficiary,
         uint256 _withdrawEnableTime
     );
+    event VaultDestroyed();
 
     /**
     * @notice Initialize a vault instance
@@ -350,6 +355,8 @@ interface IHATVault is IERC4626Upgradeable {
     * maximum percentage of the vault that can be paid out as a bounty.
     * Cannot be called if there is an active claim that has been submitted.
     * Max bounty should be less than or equal to 90% (defined as 9000).
+    * It can also be set to 100%, but in this mode the vault will only allow
+    * payouts of the 100%, and the vault will become inactive forever afterwards.
     * The pending value can be set by the owner after the time delay (of 
     * {HATVaultsRegistry.generalParameters.setMaxBountyDelay}) had passed.
     * @param _maxBounty The maximum bounty percentage that can be paid out

--- a/docs/dodoc/HATVault.md
+++ b/docs/dodoc/HATVault.md
@@ -2163,6 +2163,17 @@ event Transfer(address indexed from, address indexed to, uint256 value)
 | to `indexed` | address | undefined |
 | value  | uint256 | undefined |
 
+### VaultDestroyed
+
+```solidity
+event VaultDestroyed()
+```
+
+
+
+
+
+
 ### Withdraw
 
 ```solidity
@@ -2274,6 +2285,17 @@ error CannotTransferToAnotherUserWithActiveWithdrawRequest()
 
 ```solidity
 error CannotTransferToSelf()
+```
+
+
+
+
+
+
+### CannotUnpauseDestroyedVault
+
+```solidity
+error CannotUnpauseDestroyedVault()
 ```
 
 
@@ -2538,6 +2560,17 @@ error OnlyFeeSetter()
 
 ```solidity
 error OnlyRegistryOwner()
+```
+
+
+
+
+
+
+### PayoutMustBeHundredPercent
+
+```solidity
+error PayoutMustBeHundredPercent()
 ```
 
 

--- a/docs/dodoc/interfaces/IHATVault.md
+++ b/docs/dodoc/interfaces/IHATVault.md
@@ -932,7 +932,7 @@ Called by the vault&#39;s owner to set the vault&#39;s max bounty to the already
 function setPendingMaxBounty(uint16 _maxBounty) external nonpayable
 ```
 
-Called by the vault&#39;s owner to set a pending request for the maximum percentage of the vault that can be paid out as a bounty. Cannot be called if there is an active claim that has been submitted. Max bounty should be less than or equal to 90% (defined as 9000). The pending value can be set by the owner after the time delay (of  {HATVaultsRegistry.generalParameters.setMaxBountyDelay}) had passed.
+Called by the vault&#39;s owner to set a pending request for the maximum percentage of the vault that can be paid out as a bounty. Cannot be called if there is an active claim that has been submitted. Max bounty should be less than or equal to 90% (defined as 9000). It can also be set to 100%, but in this mode the vault will only allow payouts of the 100%, and the vault will become inactive forever afterwards. The pending value can be set by the owner after the time delay (of  {HATVaultsRegistry.generalParameters.setMaxBountyDelay}) had passed.
 
 
 
@@ -1591,6 +1591,17 @@ event Transfer(address indexed from, address indexed to, uint256 value)
 | to `indexed` | address | undefined |
 | value  | uint256 | undefined |
 
+### VaultDestroyed
+
+```solidity
+event VaultDestroyed()
+```
+
+
+
+
+
+
 ### Withdraw
 
 ```solidity
@@ -1702,6 +1713,17 @@ error CannotTransferToAnotherUserWithActiveWithdrawRequest()
 
 ```solidity
 error CannotTransferToSelf()
+```
+
+
+
+
+
+
+### CannotUnpauseDestroyedVault
+
+```solidity
+error CannotUnpauseDestroyedVault()
 ```
 
 
@@ -1966,6 +1988,17 @@ error OnlyFeeSetter()
 
 ```solidity
 error OnlyRegistryOwner()
+```
+
+
+
+
+
+
+### PayoutMustBeHundredPercent
+
+```solidity
+error PayoutMustBeHundredPercent()
 ```
 
 

--- a/test/hatvaults.js
+++ b/test/hatvaults.js
@@ -1101,7 +1101,7 @@ contract("HatVaults", (accounts) => {
       );
       assert(false, "cannot submit less than 100% when max bounty is 100% but more than MAX_BOUNTY_LIMIT");
     } catch (ex) {
-      assertVMException(ex, "PayoutMustBeHundredPercent");
+      assertVMException(ex, "PayoutMustBeUpToMaxBountyLimitOrHundredPercent");
     }
 
     tx = await vault.submitClaim(accounts[2], 10000, "description hash", {
@@ -1116,7 +1116,7 @@ contract("HatVaults", (accounts) => {
       await vault.approveClaim(claimId, 9500);
       assert(false, "cannot approve less than 100% when max bounty is 100%  but more than MAX_BOUNTY_LIMIT");
     } catch (ex) {
-      assertVMException(ex, "PayoutMustBeHundredPercent");
+      assertVMException(ex, "PayoutMustBeUpToMaxBountyLimitOrHundredPercent");
     }
 
     // assert.equal(await stakingToken.balanceOf(vault.address), web3.utils.toWei("1"));


### PR DESCRIPTION
Adds the option to set max bounty to 100%. When max bounty is 100%, only payouts of 100% can be made from the vault, and after the payout, depositing to the vault will be disabled forever, so the vault will no longer be usable.
resolves #480 