### PR TITLE
Simplify payment splitter address derivation

### DIFF
--- a/contracts/HATPaymentSplitterFactory.sol
+++ b/contracts/HATPaymentSplitterFactory.sol
@@ -8,7 +8,6 @@ import "./HATPaymentSplitter.sol";
 
 contract HATPaymentSplitterFactory {
     address public immutable implementation;
-    mapping(address => uint256) public nonce;
     event HATPaymentSplitterCreated(address indexed _hatPaymentSplitter);
 
     constructor (address _implementation) {
@@ -16,16 +15,12 @@ contract HATPaymentSplitterFactory {
     }
 
     function createHATPaymentSplitter(address[] memory _payees, uint256[] memory _shares) external returns (address result) {
-        result = Clones.cloneDeterministic(implementation, keccak256(abi.encodePacked(msg.sender, nonce[msg.sender]++)));
+        result = Clones.cloneDeterministic(implementation, keccak256(abi.encodePacked(_payees, _shares)));
         HATPaymentSplitter(payable(result)).initialize(_payees, _shares);
         emit HATPaymentSplitterCreated(result);
     }
 
-    function predictNextSplitterAddress(address _deployer) external view returns (address) {
-        return predictSplitterAddress(nonce[_deployer], _deployer);
-    }
-
-    function predictSplitterAddress(uint256 _nonce, address _deployer) public view returns (address) {
-        return Clones.predictDeterministicAddress(implementation, keccak256(abi.encodePacked(_deployer, _nonce)));
+    function predictSplitterAddress(address[] memory _payees, uint256[] memory _shares) public view returns (address) {
+        return Clones.predictDeterministicAddress(implementation, keccak256(abi.encodePacked(_payees, _shares)));
     }
 }

--- a/docs/dodoc/HATPaymentSplitterFactory.md
+++ b/docs/dodoc/HATPaymentSplitterFactory.md
@@ -50,54 +50,10 @@ function implementation() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
-### nonce
-
-```solidity
-function nonce(address) external view returns (uint256)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
-### predictNextSplitterAddress
-
-```solidity
-function predictNextSplitterAddress(address _deployer) external view returns (address)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| _deployer | address | undefined |
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
-
 ### predictSplitterAddress
 
 ```solidity
-function predictSplitterAddress(uint256 _nonce, address _deployer) external view returns (address)
+function predictSplitterAddress(address[] _payees, uint256[] _shares) external view returns (address)
 ```
 
 
@@ -108,8 +64,8 @@ function predictSplitterAddress(uint256 _nonce, address _deployer) external view
 
 | Name | Type | Description |
 |---|---|---|
-| _nonce | uint256 | undefined |
-| _deployer | address | undefined |
+| _payees | address[] | undefined |
+| _shares | uint256[] | undefined |
 
 #### Returns
 

--- a/docs/dodoc/tokenlock/TokenLockFactory.md
+++ b/docs/dodoc/tokenlock/TokenLockFactory.md
@@ -59,6 +59,28 @@ function masterCopy() external view returns (address)
 |---|---|---|
 | _0 | address | undefined |
 
+### nonce
+
+```solidity
+function nonce(address) external view returns (uint256)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
 ### owner
 
 ```solidity

--- a/test/hatvaults.js
+++ b/test/hatvaults.js
@@ -5257,15 +5257,9 @@ it("getVaultReward - no vault updates will return 0 ", async () => {
     let hatPaymentSplitterImplementation = await HATPaymentSplitter.new();
     let hatPaymentSplitterFactory = await HATPaymentSplitterFactory.new(hatPaymentSplitterImplementation.address);
 
-    let splitterAddress = await hatPaymentSplitterFactory.predictNextSplitterAddress(
-      accounts[0]
-    );
-
-    assert.equal((await hatPaymentSplitterFactory.nonce(accounts[0])).toString(), "0");
-
-    let splitterAddress2 = await hatPaymentSplitterFactory.predictSplitterAddress(
-      1,
-      accounts[0]
+    let splitterAddress = await hatPaymentSplitterFactory.predictSplitterAddress(
+      [accounts[2], accounts[3]],
+      [5000, 5000]
     );
 
     let tx = await hatPaymentSplitterFactory.createHATPaymentSplitter(
@@ -5273,26 +5267,20 @@ it("getVaultReward - no vault updates will return 0 ", async () => {
       [5000, 5000]
     );
 
-    assert.equal((await hatPaymentSplitterFactory.nonce(accounts[0])).toString(), "1");
-
     assert.equal(tx.logs[0].event, "HATPaymentSplitterCreated");
     assert.equal(tx.logs[0].args._hatPaymentSplitter, splitterAddress);
     let hatPaymentSplitter = await HATPaymentSplitter.at(splitterAddress);
 
-    tx = await hatPaymentSplitterFactory.createHATPaymentSplitter(
-      [accounts[2], accounts[3]],
-      [5000, 5000]
-    );
-
-    assert.equal(tx.logs[0].event, "HATPaymentSplitterCreated");
-    assert.equal(tx.logs[0].args._hatPaymentSplitter, splitterAddress2);
-
-    assert.equal((await hatPaymentSplitterFactory.nonce(accounts[0])).toString(), "2");
-
-    assert.equal(
-      await hatPaymentSplitterFactory.predictNextSplitterAddress(accounts[1]),
-      await hatPaymentSplitterFactory.predictSplitterAddress(0, accounts[1])
-    );
+    try {
+      await hatPaymentSplitter.initialize([accounts[2], accounts[3]], [5000, 5000]);
+      tx = await hatPaymentSplitterFactory.createHATPaymentSplitter(
+        [accounts[2], accounts[3]],
+        [5000, 5000]
+      );
+      assert(false, "already exists");
+    } catch (ex) {
+      assertVMException(ex, "Initializable: contract is already initialized");
+    }
 
     try {
       await hatPaymentSplitter.initialize([accounts[2], accounts[3]], [5000, 5000]);


### PR DESCRIPTION
Make the HATPaymentSplitterFactory derive the address of the splitter contract to be deployed based on the payees and shares used, instead of the deployer's address and nonce.