### PR TITLE
Check for duplicated reward controllers on initialize

### DIFF
--- a/contracts/HATVault.sol
+++ b/contracts/HATVault.sol
@@ -157,7 +157,10 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
         _validateSplit(_params.bountySplit);
         __ERC20_init(string.concat("Hats Vault ", _params.name), string.concat("HAT", _params.symbol));
         __ERC4626_init(IERC20MetadataUpgradeable(address(_params.asset)));
-        rewardControllers = _params.rewardControllers;
+        for (uint256 i = 0; i < _params.rewardControllers.length;) { 
+            _addRewardController(_params.rewardControllers[i]);
+            unchecked { ++i; }
+        }
         _setVestingParams(_params.vestingDuration, _params.vestingPeriods);
         HATVaultsRegistry _registry = HATVaultsRegistry(msg.sender);
         maxBounty = _params.maxBounty;
@@ -439,12 +442,7 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
 
     /** @notice See {IHATVault-addRewardController}. */
     function addRewardController(IRewardController _rewardController) external onlyRegistryOwner noActiveClaim {
-        for (uint256 i = 0; i < rewardControllers.length;) { 
-            if (_rewardController == rewardControllers[i]) revert DuplicatedRewardController();
-            unchecked { ++i; }
-        }
-        rewardControllers.push(_rewardController);
-        emit AddRewardController(_rewardController);
+        _addRewardController(_rewardController);
     }
     
     /** @notice See {IHATVault-setHATBountySplit}. */
@@ -833,6 +831,15 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
         vestingDuration = _duration;
         vestingPeriods = _periods;
         emit SetVestingParams(_duration, _periods);
+    }
+
+    function _addRewardController(IRewardController _rewardController) internal {
+        for (uint256 i = 0; i < rewardControllers.length;) { 
+            if (_rewardController == rewardControllers[i]) revert DuplicatedRewardController();
+            unchecked { ++i; }
+        }
+        rewardControllers.push(_rewardController);
+        emit AddRewardController(_rewardController);
     }
 
     /**

--- a/test/hatvaults.js
+++ b/test/hatvaults.js
@@ -733,6 +733,35 @@ contract("HatVaults", (accounts) => {
     }
   });
 
+  it("cannot create vault with duplicated reward controller", async () => {
+    await setUpGlobalVars(accounts);
+
+    let maxBounty = 8000;
+    let bountySplit = [7000, 2500, 500];
+    let stakingToken2 = await ERC20Mock.new("Staking", "STK");
+
+    try {
+      await hatVaultsRegistry.createVault({
+        asset: stakingToken2.address,
+        owner: await hatVaultsRegistry.owner(),
+        committee: accounts[3],
+        arbitrator: accounts[2],
+        name: "VAULT",
+        symbol: "VLT",
+        rewardControllers: [rewardController.address, rewardController.address],
+        maxBounty: maxBounty,
+        bountySplit: bountySplit,
+        descriptionHash: "_descriptionHash1",
+        vestingDuration: 86400,
+        vestingPeriods: 10,
+        isPaused: false
+      });
+      assert(false, "cannot create vault with duplicated reward controller");
+    } catch (ex) {
+      assertVMException(ex, "DuplicatedRewardController");
+    }
+  });
+
   it("setCommittee", async () => {
     await setUpGlobalVars(accounts);
     assert.equal(await vault.committee(), accounts[1]);


### PR DESCRIPTION
Adds a check to avoid duplicated reward controllers from being added on initialize. Also the AddRewardController event will now be emitted also for the reward controllers added on initialize.