### PR TITLE
Replace revocable enum with bool

### DIFF
--- a/contracts/HATVault.sol
+++ b/contracts/HATVault.sol
@@ -85,7 +85,6 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
 
     PendingMaxBounty public pendingMaxBounty;
 
-
     // Time of when withdrawal period starts for every user that has an
     // active withdraw request. (time when last withdraw request pending 
     // period ended, or 0 if last action was deposit or withdraw)
@@ -314,7 +313,7 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
                 vestingPeriods,
                 0, //no release start
                 0, //no cliff
-                ITokenLock.Revocability.Disabled,
+                false,
                 false
             );
             _asset.safeTransfer(tokenLock, claimBounty.hackerVested);

--- a/contracts/HATVault.sol
+++ b/contracts/HATVault.sol
@@ -313,7 +313,7 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
                 vestingPeriods,
                 0, //no release start
                 0, //no cliff
-                false,
+                false, // not revocable
                 false
             );
             _asset.safeTransfer(tokenLock, claimBounty.hackerVested);

--- a/contracts/HATVaultsRegistry.sol
+++ b/contracts/HATVaultsRegistry.sol
@@ -341,7 +341,7 @@ contract HATVaultsRegistry is IHATVaultsRegistry, Ownable {
                     generalParameters.hatVestingPeriods,
                     0, // no release start
                     0, // no cliff
-                    ITokenLock.Revocability.Disabled,
+                    false,
                     true
                 );
                 _HAT.safeTransfer(_tokenLock, _hackerReward);

--- a/contracts/HATVaultsRegistry.sol
+++ b/contracts/HATVaultsRegistry.sol
@@ -341,7 +341,7 @@ contract HATVaultsRegistry is IHATVaultsRegistry, Ownable {
                     generalParameters.hatVestingPeriods,
                     0, // no release start
                     0, // no cliff
-                    false,
+                    false, // not revocable
                     true
                 );
                 _HAT.safeTransfer(_tokenLock, _hackerReward);

--- a/contracts/tokenlock/HATTokenLock.sol
+++ b/contracts/tokenlock/HATTokenLock.sol
@@ -20,7 +20,7 @@ contract HATTokenLock is TokenLock {
         uint256 _periods,
         uint256 _releaseStartTime,
         uint256 _vestingCliffTime,
-        Revocability _revocable,
+        bool _revocable,
         bool _canDelegate
     ) external {
         _initialize(

--- a/contracts/tokenlock/ITokenLock.sol
+++ b/contracts/tokenlock/ITokenLock.sol
@@ -6,7 +6,6 @@ pragma experimental ABIEncoderV2;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface ITokenLock {
-    enum Revocability { NotSet, Enabled, Disabled }
 
     // -- Value Transfer --
 

--- a/contracts/tokenlock/ITokenLockFactory.sol
+++ b/contracts/tokenlock/ITokenLockFactory.sol
@@ -17,7 +17,7 @@ interface ITokenLockFactory {
         uint256 _periods,
         uint256 _releaseStartTime,
         uint256 _vestingCliffTime,
-        ITokenLock.Revocability _revocable,
+        bool _revocable,
         bool _canDelegate
     ) external returns(address contractAddress);
 }

--- a/contracts/tokenlock/TokenLock.sol
+++ b/contracts/tokenlock/TokenLock.sol
@@ -56,7 +56,7 @@ abstract contract TokenLock is Ownable, ITokenLock {
     // A cliff set a date to which a beneficiary needs to get to vest
     // all preceding periods
     uint256 public vestingCliffTime;
-    Revocability public revocable; // Whether to use vesting for locked funds
+    bool public revocable; // Whether to use vesting for locked funds
 
     // State
 
@@ -160,7 +160,7 @@ abstract contract TokenLock is Ownable, ITokenLock {
      * @dev Vesting schedule is always calculated based on managed tokens
      */
     function revoke() external override onlyOwner {
-        require(revocable == Revocability.Enabled, "Contract is non-revocable");
+        require(revocable, "Contract is non-revocable");
         require(isRevoked == false, "Already revoked");
 
         uint256 unvestedAmount = managedAmount - vestedAmount();
@@ -292,7 +292,7 @@ abstract contract TokenLock is Ownable, ITokenLock {
      */
     function vestedAmount() public override view returns (uint256) {
         // If non-revocable it is fully vested
-        if (revocable == Revocability.Disabled) {
+        if (!revocable) {
             return managedAmount;
         }
 
@@ -319,7 +319,7 @@ abstract contract TokenLock is Ownable, ITokenLock {
 
         // Vesting cliff is activated and it has not passed means nothing is vested yet
         // so funds cannot be released
-        if (revocable == Revocability.Enabled && vestingCliffTime > 0 && currentTime() < vestingCliffTime) {
+        if (revocable && vestingCliffTime > 0 && currentTime() < vestingCliffTime) {
             return 0;
         }
 
@@ -373,7 +373,7 @@ abstract contract TokenLock is Ownable, ITokenLock {
         uint256 _periods,
         uint256 _releaseStartTime,
         uint256 _vestingCliffTime,
-        Revocability _revocable
+        bool _revocable
     ) internal {
         require(!isInitialized, "Already initialized");
         require(_beneficiary != address(0), "Beneficiary cannot be zero");
@@ -382,7 +382,6 @@ abstract contract TokenLock is Ownable, ITokenLock {
         require(_startTime != 0, "Start time must be set");
         require(_startTime < _endTime, "Start time > end time");
         require(_periods >= MIN_PERIOD, "Periods cannot be below minimum");
-        require(_revocable != Revocability.NotSet, "Must set a revocability option");
         require(_releaseStartTime < _endTime, "Release start time must be before end time");
         require(_vestingCliffTime < _endTime, "Cliff time must be before end time");
 

--- a/contracts/tokenlock/TokenLock.sol
+++ b/contracts/tokenlock/TokenLock.sol
@@ -56,7 +56,7 @@ abstract contract TokenLock is Ownable, ITokenLock {
     // A cliff set a date to which a beneficiary needs to get to vest
     // all preceding periods
     uint256 public vestingCliffTime;
-    bool public revocable; // Whether to use vesting for locked funds
+    bool public revocable; // determines whether the owner can revoke all unvested tokens
 
     // State
 

--- a/contracts/tokenlock/TokenLockFactory.sol
+++ b/contracts/tokenlock/TokenLockFactory.sol
@@ -36,7 +36,7 @@ contract TokenLockFactory is ITokenLockFactory, Ownable {
         uint256 periods,
         uint256 releaseStartTime,
         uint256 vestingCliffTime,
-        ITokenLock.Revocability revocable,
+        bool revocable,
         bool canDelegate
     );
 
@@ -74,12 +74,12 @@ contract TokenLockFactory is ITokenLockFactory, Ownable {
         uint256 _periods,
         uint256 _releaseStartTime,
         uint256 _vestingCliffTime,
-        ITokenLock.Revocability _revocable,
+        bool _revocable,
         bool _canDelegate
     ) external override returns(address contractAddress) {
         // Create contract using a minimal proxy and call initializer
         bytes memory initializer = abi.encodeWithSignature(
-            "initialize(address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,uint8,bool)",
+            "initialize(address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bool,bool)",
             _owner,
             _beneficiary,
             _token,
@@ -131,7 +131,7 @@ contract TokenLockFactory is ITokenLockFactory, Ownable {
         uint256 _periods,
         uint256 _releaseStartTime,
         uint256 _vestingCliffTime,
-        ITokenLock.Revocability _revocable,
+        bool _revocable,
         bool _canDelegate
     ) private returns (address contractAddress) {
 

--- a/docs/dodoc/tokenlock/HATTokenLock.md
+++ b/docs/dodoc/tokenlock/HATTokenLock.md
@@ -220,7 +220,7 @@ function endTime() external view returns (uint256)
 ### initialize
 
 ```solidity
-function initialize(address _tokenLockOwner, address _beneficiary, contract HATToken _token, uint256 _managedAmount, uint256 _startTime, uint256 _endTime, uint256 _periods, uint256 _releaseStartTime, uint256 _vestingCliffTime, enum ITokenLock.Revocability _revocable, bool _canDelegate) external nonpayable
+function initialize(address _tokenLockOwner, address _beneficiary, contract HATToken _token, uint256 _managedAmount, uint256 _startTime, uint256 _endTime, uint256 _periods, uint256 _releaseStartTime, uint256 _vestingCliffTime, bool _revocable, bool _canDelegate) external nonpayable
 ```
 
 
@@ -240,7 +240,7 @@ function initialize(address _tokenLockOwner, address _beneficiary, contract HATT
 | _periods | uint256 | undefined |
 | _releaseStartTime | uint256 | undefined |
 | _vestingCliffTime | uint256 | undefined |
-| _revocable | enum ITokenLock.Revocability | undefined |
+| _revocable | bool | undefined |
 | _canDelegate | bool | undefined |
 
 ### isAccepted
@@ -455,7 +455,7 @@ function renounceOwnership() external nonpayable
 ### revocable
 
 ```solidity
-function revocable() external view returns (enum ITokenLock.Revocability)
+function revocable() external view returns (bool)
 ```
 
 
@@ -467,7 +467,7 @@ function revocable() external view returns (enum ITokenLock.Revocability)
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | enum ITokenLock.Revocability | undefined |
+| _0 | bool | undefined |
 
 ### revoke
 

--- a/docs/dodoc/tokenlock/ITokenLockFactory.md
+++ b/docs/dodoc/tokenlock/ITokenLockFactory.md
@@ -13,7 +13,7 @@
 ### createTokenLock
 
 ```solidity
-function createTokenLock(address _token, address _owner, address _beneficiary, uint256 _managedAmount, uint256 _startTime, uint256 _endTime, uint256 _periods, uint256 _releaseStartTime, uint256 _vestingCliffTime, enum ITokenLock.Revocability _revocable, bool _canDelegate) external nonpayable returns (address contractAddress)
+function createTokenLock(address _token, address _owner, address _beneficiary, uint256 _managedAmount, uint256 _startTime, uint256 _endTime, uint256 _periods, uint256 _releaseStartTime, uint256 _vestingCliffTime, bool _revocable, bool _canDelegate) external nonpayable returns (address contractAddress)
 ```
 
 
@@ -33,7 +33,7 @@ function createTokenLock(address _token, address _owner, address _beneficiary, u
 | _periods | uint256 | undefined |
 | _releaseStartTime | uint256 | undefined |
 | _vestingCliffTime | uint256 | undefined |
-| _revocable | enum ITokenLock.Revocability | undefined |
+| _revocable | bool | undefined |
 | _canDelegate | bool | undefined |
 
 #### Returns

--- a/docs/dodoc/tokenlock/TokenLock.md
+++ b/docs/dodoc/tokenlock/TokenLock.md
@@ -396,7 +396,7 @@ function renounceOwnership() external nonpayable
 ### revocable
 
 ```solidity
-function revocable() external view returns (enum ITokenLock.Revocability)
+function revocable() external view returns (bool)
 ```
 
 
@@ -408,7 +408,7 @@ function revocable() external view returns (enum ITokenLock.Revocability)
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | enum ITokenLock.Revocability | undefined |
+| _0 | bool | undefined |
 
 ### revoke
 

--- a/docs/dodoc/tokenlock/TokenLockFactory.md
+++ b/docs/dodoc/tokenlock/TokenLockFactory.md
@@ -13,7 +13,7 @@
 ### createTokenLock
 
 ```solidity
-function createTokenLock(address _token, address _owner, address _beneficiary, uint256 _managedAmount, uint256 _startTime, uint256 _endTime, uint256 _periods, uint256 _releaseStartTime, uint256 _vestingCliffTime, enum ITokenLock.Revocability _revocable, bool _canDelegate) external nonpayable returns (address contractAddress)
+function createTokenLock(address _token, address _owner, address _beneficiary, uint256 _managedAmount, uint256 _startTime, uint256 _endTime, uint256 _periods, uint256 _releaseStartTime, uint256 _vestingCliffTime, bool _revocable, bool _canDelegate) external nonpayable returns (address contractAddress)
 ```
 
 Creates and fund a new token lock wallet using a minimum proxy
@@ -33,7 +33,7 @@ Creates and fund a new token lock wallet using a minimum proxy
 | _periods | uint256 | Number of periods between start time and end time |
 | _releaseStartTime | uint256 | Override time for when the releases start |
 | _vestingCliffTime | uint256 | undefined |
-| _revocable | enum ITokenLock.Revocability | Whether the contract is revocable |
+| _revocable | bool | Whether the contract is revocable |
 | _canDelegate | bool | Whether the contract should call delegate |
 
 #### Returns
@@ -181,7 +181,7 @@ event OwnershipTransferred(address indexed previousOwner, address indexed newOwn
 ### TokenLockCreated
 
 ```solidity
-event TokenLockCreated(address indexed contractAddress, bytes32 indexed initHash, address indexed beneficiary, address token, uint256 managedAmount, uint256 startTime, uint256 endTime, uint256 periods, uint256 releaseStartTime, uint256 vestingCliffTime, enum ITokenLock.Revocability revocable, bool canDelegate)
+event TokenLockCreated(address indexed contractAddress, bytes32 indexed initHash, address indexed beneficiary, address token, uint256 managedAmount, uint256 startTime, uint256 endTime, uint256 periods, uint256 releaseStartTime, uint256 vestingCliffTime, bool revocable, bool canDelegate)
 ```
 
 
@@ -202,7 +202,7 @@ event TokenLockCreated(address indexed contractAddress, bytes32 indexed initHash
 | periods  | uint256 | undefined |
 | releaseStartTime  | uint256 | undefined |
 | vestingCliffTime  | uint256 | undefined |
-| revocable  | enum ITokenLock.Revocability | undefined |
+| revocable  | bool | undefined |
 | canDelegate  | bool | undefined |
 
 

--- a/test/hatvaults.js
+++ b/test/hatvaults.js
@@ -6347,7 +6347,7 @@ it("getVaultReward - no vault updates will return 0 ", async () => {
     assert.isTrue(
       expectedHackerBalance.eq(await vestingTokenLock.managedAmount())
     );
-    assert.equal(await vestingTokenLock.revocable(), 2); //Disable
+    assert.equal(await vestingTokenLock.revocable(), false); //Disable
     assert.equal(await vestingTokenLock.canDelegate(), false);
 
     //hacker get also rewards via none vesting


### PR DESCRIPTION
This is a small simplification which also saves a bit of contract size. Currently the Revocable option of the token lock is an enum, but only the enabled and disabled options are usable, so this could be simply replaced by a bool instead.