### PR TITLE
Fix potentially wrong committee address

### DIFF
--- a/contracts/HATVault.sol
+++ b/contracts/HATVault.sol
@@ -216,7 +216,7 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
             claimId: claimId,
             beneficiary: _beneficiary,
             bountyPercentage: _bountyPercentage,
-            committee: msg.sender,
+            committee: committee,
             // solhint-disable-next-line not-rely-on-time
             createdAt: uint32(block.timestamp),
             challengedAt: 0,
@@ -231,6 +231,7 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
 
         emit SubmitClaim(
             claimId,
+            committee,
             msg.sender,
             _beneficiary,
             _bountyPercentage,
@@ -342,6 +343,7 @@ contract HATVault is IHATVault, ERC4626Upgradeable, OwnableUpgradeable, Reentran
 
         emit ApproveClaim(
             _claimId,
+            _claim.committee,
             msg.sender,
             _claim.beneficiary,
             _claim.bountyPercentage,

--- a/contracts/interfaces/IHATVault.sol
+++ b/contracts/interfaces/IHATVault.sol
@@ -234,7 +234,7 @@ interface IHATVault is IERC4626Upgradeable {
 
     event SubmitClaim(
         bytes32 indexed _claimId,
-        address indexed _committee,
+        address _committee,
         address indexed _submitter,
         address indexed _beneficiary,
         uint256 _bountyPercentage,
@@ -243,7 +243,7 @@ interface IHATVault is IERC4626Upgradeable {
     event ChallengeClaim(bytes32 indexed _claimId);
     event ApproveClaim(
         bytes32 indexed _claimId,
-        address indexed _committee,
+        address _committee,
         address indexed _approver,
         address indexed _beneficiary,
         uint256 _bountyPercentage,

--- a/contracts/interfaces/IHATVault.sol
+++ b/contracts/interfaces/IHATVault.sol
@@ -235,6 +235,7 @@ interface IHATVault is IERC4626Upgradeable {
     event SubmitClaim(
         bytes32 indexed _claimId,
         address indexed _committee,
+        address indexed _submitter,
         address indexed _beneficiary,
         uint256 _bountyPercentage,
         string _descriptionHash
@@ -243,6 +244,7 @@ interface IHATVault is IERC4626Upgradeable {
     event ApproveClaim(
         bytes32 indexed _claimId,
         address indexed _committee,
+        address indexed _approver,
         address indexed _beneficiary,
         uint256 _bountyPercentage,
         address _tokenLock,

--- a/docs/dodoc/HATVault.md
+++ b/docs/dodoc/HATVault.md
@@ -1857,7 +1857,7 @@ event Approval(address indexed owner, address indexed spender, uint256 value)
 ### ApproveClaim
 
 ```solidity
-event ApproveClaim(bytes32 indexed _claimId, address indexed _committee, address indexed _beneficiary, uint256 _bountyPercentage, address _tokenLock, IHATVault.ClaimBounty _claimBounty)
+event ApproveClaim(bytes32 indexed _claimId, address _committee, address indexed _approver, address indexed _beneficiary, uint256 _bountyPercentage, address _tokenLock, IHATVault.ClaimBounty _claimBounty)
 ```
 
 
@@ -1869,7 +1869,8 @@ event ApproveClaim(bytes32 indexed _claimId, address indexed _committee, address
 | Name | Type | Description |
 |---|---|---|
 | _claimId `indexed` | bytes32 | undefined |
-| _committee `indexed` | address | undefined |
+| _committee  | address | undefined |
+| _approver `indexed` | address | undefined |
 | _beneficiary `indexed` | address | undefined |
 | _bountyPercentage  | uint256 | undefined |
 | _tokenLock  | address | undefined |
@@ -2185,7 +2186,7 @@ event SetWithdrawalFee(uint256 _newFee)
 ### SubmitClaim
 
 ```solidity
-event SubmitClaim(bytes32 indexed _claimId, address indexed _committee, address indexed _beneficiary, uint256 _bountyPercentage, string _descriptionHash)
+event SubmitClaim(bytes32 indexed _claimId, address _committee, address indexed _submitter, address indexed _beneficiary, uint256 _bountyPercentage, string _descriptionHash)
 ```
 
 
@@ -2197,7 +2198,8 @@ event SubmitClaim(bytes32 indexed _claimId, address indexed _committee, address 
 | Name | Type | Description |
 |---|---|---|
 | _claimId `indexed` | bytes32 | undefined |
-| _committee `indexed` | address | undefined |
+| _committee  | address | undefined |
+| _submitter `indexed` | address | undefined |
 | _beneficiary `indexed` | address | undefined |
 | _bountyPercentage  | uint256 | undefined |
 | _descriptionHash  | string | undefined |

--- a/docs/dodoc/interfaces/IHATVault.md
+++ b/docs/dodoc/interfaces/IHATVault.md
@@ -1329,7 +1329,7 @@ event Approval(address indexed owner, address indexed spender, uint256 value)
 ### ApproveClaim
 
 ```solidity
-event ApproveClaim(bytes32 indexed _claimId, address indexed _committee, address indexed _beneficiary, uint256 _bountyPercentage, address _tokenLock, IHATVault.ClaimBounty _claimBounty)
+event ApproveClaim(bytes32 indexed _claimId, address _committee, address indexed _approver, address indexed _beneficiary, uint256 _bountyPercentage, address _tokenLock, IHATVault.ClaimBounty _claimBounty)
 ```
 
 
@@ -1341,7 +1341,8 @@ event ApproveClaim(bytes32 indexed _claimId, address indexed _committee, address
 | Name | Type | Description |
 |---|---|---|
 | _claimId `indexed` | bytes32 | undefined |
-| _committee `indexed` | address | undefined |
+| _committee  | address | undefined |
+| _approver `indexed` | address | undefined |
 | _beneficiary `indexed` | address | undefined |
 | _bountyPercentage  | uint256 | undefined |
 | _tokenLock  | address | undefined |
@@ -1624,7 +1625,7 @@ event SetWithdrawalFee(uint256 _newFee)
 ### SubmitClaim
 
 ```solidity
-event SubmitClaim(bytes32 indexed _claimId, address indexed _committee, address indexed _beneficiary, uint256 _bountyPercentage, string _descriptionHash)
+event SubmitClaim(bytes32 indexed _claimId, address _committee, address indexed _submitter, address indexed _beneficiary, uint256 _bountyPercentage, string _descriptionHash)
 ```
 
 
@@ -1636,7 +1637,8 @@ event SubmitClaim(bytes32 indexed _claimId, address indexed _committee, address 
 | Name | Type | Description |
 |---|---|---|
 | _claimId `indexed` | bytes32 | undefined |
-| _committee `indexed` | address | undefined |
+| _committee  | address | undefined |
+| _submitter `indexed` | address | undefined |
 | _beneficiary `indexed` | address | undefined |
 | _bountyPercentage  | uint256 | undefined |
 | _descriptionHash  | string | undefined |

--- a/docs/dodoc/mocks/HATVaultV2Mock.md
+++ b/docs/dodoc/mocks/HATVaultV2Mock.md
@@ -1874,7 +1874,7 @@ event Approval(address indexed owner, address indexed spender, uint256 value)
 ### ApproveClaim
 
 ```solidity
-event ApproveClaim(bytes32 indexed _claimId, address indexed _committee, address indexed _beneficiary, uint256 _bountyPercentage, address _tokenLock, IHATVault.ClaimBounty _claimBounty)
+event ApproveClaim(bytes32 indexed _claimId, address _committee, address indexed _approver, address indexed _beneficiary, uint256 _bountyPercentage, address _tokenLock, IHATVault.ClaimBounty _claimBounty)
 ```
 
 
@@ -1886,7 +1886,8 @@ event ApproveClaim(bytes32 indexed _claimId, address indexed _committee, address
 | Name | Type | Description |
 |---|---|---|
 | _claimId `indexed` | bytes32 | undefined |
-| _committee `indexed` | address | undefined |
+| _committee  | address | undefined |
+| _approver `indexed` | address | undefined |
 | _beneficiary `indexed` | address | undefined |
 | _bountyPercentage  | uint256 | undefined |
 | _tokenLock  | address | undefined |
@@ -2202,7 +2203,7 @@ event SetWithdrawalFee(uint256 _newFee)
 ### SubmitClaim
 
 ```solidity
-event SubmitClaim(bytes32 indexed _claimId, address indexed _committee, address indexed _beneficiary, uint256 _bountyPercentage, string _descriptionHash)
+event SubmitClaim(bytes32 indexed _claimId, address _committee, address indexed _submitter, address indexed _beneficiary, uint256 _bountyPercentage, string _descriptionHash)
 ```
 
 
@@ -2214,7 +2215,8 @@ event SubmitClaim(bytes32 indexed _claimId, address indexed _committee, address 
 | Name | Type | Description |
 |---|---|---|
 | _claimId `indexed` | bytes32 | undefined |
-| _committee `indexed` | address | undefined |
+| _committee  | address | undefined |
+| _submitter `indexed` | address | undefined |
 | _beneficiary `indexed` | address | undefined |
 | _bountyPercentage  | uint256 | undefined |
 | _descriptionHash  | string | undefined |

--- a/test/hatvaults.js
+++ b/test/hatvaults.js
@@ -723,16 +723,20 @@ contract("HatVaults", (accounts) => {
 
     try {
       await vault.initialize({
-        asset: stakingToken.address,
+        asset: stakingToken2.address,
         owner: await hatVaultsRegistry.owner(),
-        committee: accounts[1],
+        committee: accounts[3],
         arbitrator: accounts[2],
+        arbitratorCanChangeBounty: true,
+        arbitratorCanChangeBeneficiary: false,
+        arbitratorCanSubmitClaims: false,
+        isTokenLockRevocable: false,
         name: "VAULT",
         symbol: "VLT",
         rewardControllers: [rewardController.address],
-        maxBounty: 8000,
-        bountySplit: [7000, 2500, 500],
-        descriptionHash: "_descriptionHash",
+        maxBounty: maxBounty,
+        bountySplit: bountySplit,
+        descriptionHash: "_descriptionHash1",
         vestingDuration: 86400,
         vestingPeriods: 10,
         isPaused: false
@@ -3653,6 +3657,7 @@ it("getVaultReward - no vault updates will return 0 ", async () => {
  
     assert.equal(tx.logs[0].event, "SubmitClaim");
     assert.equal(tx.logs[0].args._committee, accounts[1]);
+    assert.equal(tx.logs[0].args._submitter, accounts[1]);
     assert.equal(tx.logs[0].args._beneficiary, accounts[2]);
     assert.equal(tx.logs[0].args._bountyPercentage, 8000);
     assert.equal(tx.logs[0].args._descriptionHash, "description hash");


### PR DESCRIPTION
Fix committee address being potentially saved wrongly when submitting claim and emitted wrongly approving claim